### PR TITLE
Modified tex2pdf to fail without hanging

### DIFF
--- a/publisher/build_paper.py
+++ b/publisher/build_paper.py
@@ -60,7 +60,9 @@ def rst2tex(in_path, out_path):
                 'use_verbatim_when_possible': True,
                 'use_latex_citations': True,
                 'latex_preamble': preamble,
-                'documentoptions': 'letterpaper,compsoc,twoside'}
+                'documentoptions': 'letterpaper,compsoc,twoside',
+                'halt_level': 3,  # 2: warn; 3: error; 4: severe
+                }
 
     try:
         rst, = glob.glob(os.path.join(in_path, '*.rst'))


### PR DESCRIPTION
This can happen when files are missing. pdflatex asks for files via stdin, but
tex2pdf is capturing stdout to make up for pdflatex not providing a valid
integer return code to indicate failure.

This patch aims at #49.
