### PR TITLE
fix issue #3 of whitespace mishandling

### DIFF
--- a/publisher/build_paper.py
+++ b/publisher/build_paper.py
@@ -94,7 +94,7 @@ def rst2tex(in_path, out_path):
 def tex2pdf(out_path):
 
     import subprocess
-    command_line = 'cd %s ' % out_path + \
+    command_line = 'cd "%s" ' % out_path + \
                    ' ; pdflatex -halt-on-error paper.tex'
 
     # -- dummy tempfile is a hacky way to prevent pdflatex


### PR DESCRIPTION
whitespaces are now escaped with quotes
in the shell command that builds the PDF
