### PR TITLE
Set default tablewidth to 0.8 linewidth.

### DIFF
--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -319,7 +319,7 @@ class Translator(LaTeXTranslator):
         self.active_table.caption = []
 
         opening = self.active_table.get_opening()
-        opening = opening.replace('linewidth', 'tablewidth')
+        opening = opening.replace(r'{\linewidth}', r'{0.8\linewidth}')
         self.active_table.get_opening = lambda: opening
 
         LaTeXTranslator.visit_thead(self, node)


### PR DESCRIPTION
This setting has improved the layout for EuroSciPy's proceedings.
