### PR TITLE
added support for multiple institution affiliations per author

### DIFF
--- a/papers/00_vanderwalt/00_vanderwalt.rst
+++ b/papers/00_vanderwalt/00_vanderwalt.rst
@@ -1,6 +1,7 @@
 :author: Gaius Caesar
 :email: jj@rome.it
 :institution: Senate House, S.P.Q.R.
+:institution: Egyptian Embassy, S.P.Q.R.
 
 :author: Mark Anthony
 :email: mark37@rome.it
@@ -9,6 +10,11 @@
 :author: Jarrod Millman
 :email: millman@rome.it
 :institution: Egyptian Embassy, S.P.Q.R.
+:institution: Yet another place, S.P.Q.R.
+
+:author: Brutus
+:email: brutus@rome.it
+:institution: Unaffiliated
 
 :video: http://www.youtube.com/watch?v=dhRUe-gz690
 


### PR DESCRIPTION
ref #120

This PR changes the author-institution data structure into many-to-many mapping, so that each author can have multiple affiliations without redundant \thanks clauses.

I've only tested this with pdf output on the sample doc (with some modifications to make sure it works).