### PR TITLE
[Issue 169] Copyright Holder Different Than Author

### DIFF
--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -30,6 +30,7 @@ class Translator(LaTeXTranslator):
 
         self.current_field = ''
 
+        self.copyright_holder = None
         self.author_names = []
         self.author_institutions = []
         self.author_institution_map = dict()
@@ -81,6 +82,8 @@ class Translator(LaTeXTranslator):
         elif self.current_field == 'institution':
             self.author_institutions.append(text)
             self.author_institution_map[self.author_names[-1]].append(text)
+        elif self.current_field == 'copyright_holder':
+            self.copyright_holder = text
         elif self.current_field == 'video':
             self.video_url = text
 
@@ -161,7 +164,7 @@ class Translator(LaTeXTranslator):
             self.author_emails = ['john@doe.com']
             authors = ['']
 
-        copyright_holder = self.author_names[0] + ('.' if len(self.author_names) == 1 else ' et al.')
+        copyright_holder = self.copyright_holder or (self.author_names[0] + ('.' if len(self.author_names) == 1 else ' et al.'))
         author_notes = r'''%%
 
           \noindent%%


### PR DESCRIPTION
Added a copyright_holder tag that can be used to replace the authors' copyright with an author-defined one.

Sample usage would be:

:author: Joe Author
:email: joe@author.org

:copyright_holder: My Company, Inc.