### PR TITLE
Footmarks

### DIFF
--- a/papers/00_vanderwalt/00_vanderwalt.rst
+++ b/papers/00_vanderwalt/00_vanderwalt.rst
@@ -2,6 +2,7 @@
 :email: jj@rome.it
 :institution: Senate House, S.P.Q.R.
 :institution: Egyptian Embassy, S.P.Q.R.
+:corresponding: True
 
 :author: Mark Anthony
 :email: mark37@rome.it
@@ -11,10 +12,12 @@
 :email: millman@rome.it
 :institution: Egyptian Embassy, S.P.Q.R.
 :institution: Yet another place, S.P.Q.R.
+:equal: True
 
 :author: Brutus
 :email: brutus@rome.it
 :institution: Unaffiliated
+:equal: True
 
 :video: http://www.youtube.com/watch?v=dhRUe-gz690
 
@@ -94,7 +97,7 @@ Or a snippet from the above code, starting at the correct line number:
    for (int i = 0; i < 10; i++) {
        /* do something */
    }
- 
+
 Important Part
 --------------
 

--- a/papers/00_vanderwalt/00_vanderwalt.rst
+++ b/papers/00_vanderwalt/00_vanderwalt.rst
@@ -12,12 +12,12 @@
 :email: millman@rome.it
 :institution: Egyptian Embassy, S.P.Q.R.
 :institution: Yet another place, S.P.Q.R.
-:equal: True
+:equal-contributor:
 
 :author: Brutus
 :email: brutus@rome.it
 :institution: Unaffiliated
-:equal: True
+:equal-contributor:
 
 :video: http://www.youtube.com/watch?v=dhRUe-gz690
 

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -36,7 +36,7 @@ class Translator(LaTeXTranslator):
         self.author_institution_map = dict()
         self.author_emails = []
         self.corresponding = []
-        self.equal_authors = []
+        self.equal_contributors = []
         self.paper_title = ''
         self.abstract_text = []
         self.keywords = ''
@@ -100,8 +100,8 @@ class Translator(LaTeXTranslator):
             self.author_emails.append(text)
         elif self.current_field == 'corresponding':
             self.corresponding.append(self.author_names[-1])
-        elif self.current_field == 'equal':
-            self.equal_authors.append(self.author_names[-1])
+        elif self.current_field == 'equal-contributor':
+            self.equal_contributors.append(self.author_names[-1])
         elif self.current_field == 'institution':
             self.author_institutions.append(text)
             self.author_institution_map[self.author_names[-1]].append(text)
@@ -136,7 +136,7 @@ class Translator(LaTeXTranslator):
         def footmark(n):
             """Insert footmark #n.  Footmark 1 is reserved for
             the corresponding author. Footmark 2 is reserved for
-            the equal authors.\
+            the equal contributors.\
             """
             return ('\\setcounter{footnotecounter}{%d}' % n,
                     '\\fnsymbol{footnotecounter}')
@@ -144,7 +144,7 @@ class Translator(LaTeXTranslator):
         # Build a footmark for the corresponding author
         corresponding_footmark = footmark(1)
 
-        # Build a footmark for equal authors
+        # Build a footmark for equal contributors
         equal_footmark = footmark(2)
 
         # Build one footmark for each institution
@@ -157,7 +157,7 @@ class Translator(LaTeXTranslator):
           %(footmark_counter)s\thanks{%(footmark)s %%
           Corresponding author: \protect\href{mailto:%(email)s}{%(email)s}}'''
 
-        equal_auth_template = r'''%%
+        equal_contrib_template = r'''%%
           %(footmark_counter)s\thanks{%(footmark)s %%
           These authors contributed equally.}'''
 
@@ -174,7 +174,7 @@ class Translator(LaTeXTranslator):
         for n, auth in enumerate(self.author_names):
             # get footmarks
             footmarks = ''.join([''.join(institute_footmark[inst]) for inst in self.author_institution_map[auth]])
-            if auth in self.equal_authors:
+            if auth in self.equal_contributors:
                 footmarks += ''.join(equal_footmark)
             if auth in self.corresponding:
                 footmarks += ''.join(corresponding_footmark)
@@ -182,9 +182,9 @@ class Translator(LaTeXTranslator):
                         {'author': auth,
                         'footmark': footmarks}]
 
-            if auth in self.equal_authors:
+            if auth in self.equal_contributors:
                 fm_counter, fm = equal_footmark
-                authors[-1] += equal_auth_template % \
+                authors[-1] += equal_contrib_template % \
                     {'footmark_counter': fm_counter,
                      'footmark': fm}
 

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -1,4 +1,5 @@
-__all__ = ['writer']
+_
+all__ = ['writer']
 
 import docutils.core as dc
 import docutils.writers
@@ -96,9 +97,9 @@ class Translator(LaTeXTranslator):
         if self.current_field == 'email':
             self.author_emails.append(text)
         elif self.current_field == 'corresponding':
-            self.author_corresponding_map[self.author_names[-1]].append(bool(text))
-        elif self.current_field == 'corresponding':
-            self.author_equal_map[self.author_names[-1]].append(bool(text))
+            self.author_corresponding.append(self.author_names[-1])
+        elif self.current_field == 'equal':
+            self.author_equal.append(self.author_names[-1])
         elif self.current_field == 'institution':
             self.author_institutions.append(text)
             self.author_institution_map[self.author_names[-1]].append(text)
@@ -160,26 +161,29 @@ class Translator(LaTeXTranslator):
 
         title = self.paper_title
         authors = []
+        corr_emails = []
+        if len(authors_corresponding) == 0:
+            authors_corresponding = [self.author_names[0]]
         institutions_mentioned = set()
         for n, auth in enumerate(self.author_names):
             # get footmarks
             footmarks = ''
             if auth in self.author_corresponding:
                 footmarks.join(corresponding_footmark)
-            if auth in self.author_equal_map:
+                corr_emails.append(self.emails[n])
+            if auth in self.author_equal:
                 footmarks.join(equal_footmark)
             for inst in self.author_institution_map[auth]:
                 footmarks.join(institute_footmark[inst]
 
-
-                fm_counter, fm = corresponding_footmark
-                authors[-1] += corresponding_auth_template % \
-                               {'footmark_counter': fm_counter,
-                                'footmark': fm,
-                                'email': self.author_emails[n]}
-                authors += [r'%(author)s$^{%(footmark)s}$' % \
-                            {'author': auth,
-                             'footmark': footmarks}]
+            fm_counter, fm = corresponding_footmark
+            authors[-1] += corresponding_auth_template % \
+                            {'footmark_counter': fm_counter,
+                            'footmark': fm,
+                            'email': ', '.join(corr_emails)}
+            authors += [r'%(author)s$^{%(footmark)s}$' % \
+                        {'author': auth,
+                         'footmark': footmarks}]
 
             for inst in self.author_institution_map[auth]:
                 if not inst in institutions_mentioned:
@@ -191,7 +195,7 @@ class Translator(LaTeXTranslator):
 
                 institutions_mentioned.add(inst)
 
-
+        if len(corresponding_auth
         ## Add copyright
 
         # If things went spectacularly wrong, we could not even parse author

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -157,7 +157,7 @@ class Translator(LaTeXTranslator):
 
         equal_auth_template = r'''%%
           %(footmark_counter)s\thanks{%(footmark)s %%
-          These authors contributed equally.'''
+          These authors contributed equally.}'''
 
         title = self.paper_title
         authors = []
@@ -179,6 +179,13 @@ class Translator(LaTeXTranslator):
             authors += [r'%(author)s$^{%(footmark)s}$' %
                         {'author': auth,
                         'footmark': footmarks}]
+
+            if auth in self.equal_authors:
+                fm_counter, fm = equal_footmark
+                authors[-1] += equal_auth_template % \
+                    {'footmark_counter': fm_counter,
+                     'footmark': fm}
+
             if auth in self.corresponding:
                 fm_counter, fm = corresponding_footmark
                 authors[-1] += corresponding_auth_template % \


### PR DESCRIPTION
This allows for the following options to any (and, indeed, many) to be added to any author definitions in the paper header:

```
:corresponding: True
:equal: True
```

- these are optional, 
- the default is to have the first author be the corresponding author 
- and the default is to have no indication of equal authorship

However, if you want two authors to have a footnote indicating that they contributed equally to the paper, include the `:equal: True` tag to each of their area of the header. 

If you want one or more people other than the first to be the corresponding author, put `:corresponding: True:` in their area of the header.

It would be great if @stefanv could review this. Note that it seeks to solve #144 desired by @adamrp, @jackiekazil, and @philippjfr .