### PR TITLE
Python 3 compatibility for building papers

### DIFF
--- a/publisher/build_paper.py
+++ b/publisher/build_paper.py
@@ -97,7 +97,11 @@ def rst2tex(in_path, out_path):
         print("Error: no paper configuration found")
 
     tex_file = os.path.join(out_path, 'paper.tex')
-    with open(tex_file, 'w') as f:
+    with open(tex_file, 'wb') as f:
+        try:
+            tex = tex.encode('utf-8')
+        except (AttributeError, UnicodeDecodeError):
+            pass
         f.write(tex)
 
 
@@ -118,13 +122,13 @@ def tex2pdf(out_path):
             )
     out, err = run.communicate()
 
-    if "Fatal" in out or run.returncode:
+    if "Fatal" in out.decode() or run.returncode:
         print("PDFLaTeX error output:")
         print("=" * 80)
-        print(out)
+        print(out.decode())
         print("=" * 80)
         if err:
-            print(err)
+            print(err.decode())
             print("=" * 80)
 
         # Errors, exit early
@@ -179,7 +183,7 @@ def page_count(pdflatex_stdout, paper_dir):
     d = options.cfg2dict(cfgname)
 
     for line in pdflatex_stdout.splitlines():
-        m = regexp.match(line)
+        m = regexp.match(line.decode())
         if m:
             pages = m.groups()[0]
             d.update({'pages': int(pages)})

--- a/publisher/build_papers.py
+++ b/publisher/build_papers.py
@@ -29,7 +29,7 @@ def paper_stats(paper_id, start):
 
     stop = start + pages - 1
 
-    print '"%s" from p. %s to %s' % (paper_id, start, stop)
+    print('"%s" from p. %s to %s' % (paper_id, start, stop))
 
     with open(os.path.join(output_dir, paper_id, 'page_numbers.tex'), 'w') as f:
         f.write('\setcounter{page}{%s}' % start)

--- a/publisher/build_template.py
+++ b/publisher/build_template.py
@@ -10,7 +10,9 @@ from options import get_config
 
 class TeXTemplate(tempita.Template):
     def _repr(self, value, pos):
-        if isinstance(value, unicode):
+        if sys.version_info[0] < 3 and isinstance(value, unicode):
+            value = value.replace('&', '\&')
+        elif sys.version_info[0] >= 3 and isinstance(value, str):
             value = value.replace('&', '\&')
         else:
             value = str(value)
@@ -63,14 +65,14 @@ def html_from_tmpl(src, config, target):
 if __name__ == "__main__":
 
     if not len(sys.argv) == 2:
-        print "Usage: build_template.py destination_name"
+        print("Usage: build_template.py destination_name")
         sys.exit(-1)
 
     dest_fn = sys.argv[1]
     template_fn = os.path.join(template_dir, dest_fn+'.tmpl')
 
     if not os.path.exists(template_fn):
-        print "Cannot find template."
+        print("Cannot find template.")
         sys.exit(-1)
 
     config = get_config()

--- a/publisher/mail/_mailer.py
+++ b/publisher/mail/_mailer.py
@@ -25,7 +25,7 @@ def parse_args():
     args.dry_run = not args.send
 
     if args.dry_run:
-        print '*** This is a dry run.  Use --send to send emails.'
+        print('*** This is a dry run.  Use --send to send emails.')
 
     return args
 
@@ -47,18 +47,18 @@ def email_addr_from(name_email):
 def send_template(sender, recipient, template, template_data,
                   smtp_server='smtp.gmail.com', smtp_port=587):
     if args.dry_run:
-        print 'Dry run -> not sending mail to %s' % recipient
+        print('Dry run -> not sending mail to %s' % recipient)
     else:
         get_password(sender['login'])
-        print '-> %s' % recipient
+        print('-> %s' % recipient)
 
     template_data['email'] = recipient
     message = _from_template('../mail/templates/' + template, template_data)
 
     if args.dry_run:
-        print "=" * 80
-        print message
-        print "=" * 80
+        print("=" * 80)
+        print(message)
+        print("=" * 80)
 
         return
 

--- a/publisher/mail/mail_authors.py
+++ b/publisher/mail/mail_authors.py
@@ -9,4 +9,4 @@ for author in config['authors']:
     to = mailer.email_addr_from(author)
     mailer.send_template(config['sender'], to, args.template, config)
 
-print "Mail for %d authors." % len(config['authors'])
+print("Mail for %d authors." % len(config['authors']))

--- a/publisher/mail/mail_reviewers.py
+++ b/publisher/mail/mail_reviewers.py
@@ -33,11 +33,11 @@ for reviewer_info in config['reviewers']:
         d.append(reviewer_info['name'])
 
 for paper in paper_reviewers:
-    print "%s:" % paper
+    print("%s:" % paper)
     for reviewer in paper_reviewers[paper]:
-        print "->", reviewer
+        print("->", reviewer)
     print
 
-print "Papers:", len(paper_reviewers)
-print "Reviewers:", len(config['reviewers'])
+print("Papers:", len(paper_reviewers))
+print("Reviewers:", len(config['reviewers']))
 print

--- a/publisher/options.py
+++ b/publisher/options.py
@@ -22,7 +22,7 @@ def cfg2dict(filename):
 
     """
     if not os.path.exists(filename):
-        print '*** Warning: %s does not exist.' % filename
+        print('*** Warning: %s does not exist.' % filename)
         return {}
 
     return json.loads(codecs.open(filename, 'r', 'utf-8').read())

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -7,8 +7,8 @@ from docutils import nodes
 from docutils.writers.latex2e import (Writer, LaTeXTranslator,
                                       PreambleCmds)
 
-from rstmath import mathEnv
-import code_block
+from .rstmath import mathEnv
+from . import code_block
 
 from options import options
 


### PR DESCRIPTION
This fixes the errors that arise when running `make_paper.sh` under Python 3; there are still some issues related to `tempita` that prevent the proceedings from building correctly, but this is a start at least.

cc: @stefanv