### PR TITLE
Proposal: Change default BibTeX style from alpha to alphaurl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ examples of how to:
 ## Requirements
 
  - IEEETran (often packaged as ``texlive-publishers``, or download from
-   [CTAN](http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/) LaTeX
+   [CTAN](http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/)) LaTeX
    class
  - AMSmath LaTeX classes (included in most LaTeX distributions)
+ - alphaurl (often packaged as ``texlive-bibtex-extra``, or download from
+   [CTAN](https://www.ctan.org/pkg/urlbst)) urlbst BibTeX style
  - `docutils` 0.8 or later (``easy_install docutils``)
  - `pygments` for code highlighting (``easy_install pygments``)
  - Due to a bug in the Debian packaging of ``pdfannotextractor``, you may have
@@ -110,7 +112,8 @@ On Debian-like distributions:
 
 ```
 sudo apt-get install python-docutils texlive-latex-base texlive-publishers \
-                     texlive-latex-extra texlive-fonts-recommended
+                     texlive-latex-extra texlive-fonts-recommended \
+                     texlive-bibtex-extra
 ```
 
 Note you will still need to install `docutils` with `easy-install` or `pip` even on a Debian system.
@@ -118,7 +121,7 @@ Note you will still need to install `docutils` with `easy-install` or `pip` even
 On Fedora, the package names are slightly different
 
 ```
-su -c `dnf install python-docutils texlive-collection-basic texlive-collection-fontsrecommended texlive-collection-latex texlive-collection-latexrecommended texlive-collection-latexextra texlive-collection-publishers`
+su -c `dnf install python-docutils texlive-collection-basic texlive-collection-fontsrecommended texlive-collection-latex texlive-collection-latexrecommended texlive-collection-latexextra texlive-collection-publishers texlive-collection-bibtexextra`
 ```
 
 ## Build Server

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -110,7 +110,7 @@ class Translator(LaTeXTranslator):
         elif self.current_field == 'video':
             self.video_url = text
         elif self.current_field == 'bibliography':
-            self.bibtex = ['alpha', text]
+            self.bibtex = ['alphaurl', text]
             self._use_latex_citations = True
             self._bibitems = ['', '']
             self.bibliography = text


### PR DESCRIPTION
This is a proposal to change the default BibTeX style used in the SciPy proceedings to `alphaurl`.

The `alpha` BibTeX style currently used in the SciPy proceedings does not support the `doi` and `url` BibTeX fields. The [suggested review criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/review_criteria.md) as well as major publishers (e.g. [Elsevier](https://www.elsevier.com/journals/neurocomputing/0925-2312/guide-for-authors) and [IEEE](http://www.ieee.org/documents/ieeecitationref.pdf)) encourage the use of the DOI. Thus, the BibTeX style used in the SciPy proceedings should be changed to one that supports the `doi` and `url` fields.

The `alphaurl` BibTeX style from the [urlbst](https://www.ctan.org/pkg/urlbst) project is a minimum modification of the `alpha` style to support the `url` and `doi` fields. 

An example of a reference using the `alpha` style:
![opa14_alpha](https://cloud.githubusercontent.com/assets/5367057/15532209/d36ff856-225e-11e6-8fbd-443a4b784540.png)

The same reference using the `alphaurl` style with a DOI:
![opa14_alphaurl](https://cloud.githubusercontent.com/assets/5367057/15532221/ead3dbf2-225e-11e6-843b-3ce27e389b37.png)




