### PR TITLE
Publisher dies if natbib complains error.

### DIFF
--- a/publisher/build_paper.py
+++ b/publisher/build_paper.py
@@ -169,8 +169,7 @@ def tex2pdf_singlepass(out_path):
                 cwd=out_path,
                 )
         out_bib, err = run.communicate()
-
-        if err:
+        if err or 'Error' in out_bib:
             print("Error compiling BiBTeX")
             return out_bib, False
 


### PR DESCRIPTION
This may be too strict. But it is never bad to be too strict.

This should give an error on #192 (instead of giving question marks)