### PR TITLE
Fix Python3 error introduced in 6794ca5

### DIFF
--- a/publisher/build_paper.py
+++ b/publisher/build_paper.py
@@ -169,7 +169,7 @@ def tex2pdf_singlepass(out_path):
                 cwd=out_path,
                 )
         out_bib, err = run.communicate()
-        if err or 'Error' in out_bib:
+        if err or 'Error' in out_bib.decode():
             print("Error compiling BiBTeX")
             return out_bib, False
 


### PR DESCRIPTION
(re-opening as a PR to master instead of 2016)

6794ca5 restored some Python 3-incompatible code that was fixed in #182. This restores the correct version which works under 2 and 3.

```
scipy_proceedings git:(2016) ✗ ./make_paper.sh papers/brett_naul
Building: brett_naul
*** Warning: /Users/brettnaul/Dropbox/Documents/scipy_proceedings/publisher/../output/brett_naul/paper_stats.json does not exist.
Traceback (most recent call last):
  File "publisher/build_paper.py", line 225, in <module>
    build_paper(paper_id)
  File "publisher/build_paper.py", line 211, in build_paper
    pdflatex_stdout = tex2pdf(out_path)
  File "publisher/build_paper.py", line 113, in tex2pdf
    out, retry = tex2pdf_singlepass(out_path)
  File "publisher/build_paper.py", line 172, in tex2pdf_singlepass
    if err or 'Error' in out_bib:
TypeError: a bytes-like object is required, not 'str'
```