### PR TITLE
2016 --> 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ paper:
   [scipy_proceedings](https://github.com/scipy-conference/scipy_proceedings)
   repository on GitHub.
 
-- Check out the 2016 branch (``git checkout 2016``).
+- Check out the 2017 branch (``git checkout 2017``).
 
 - An example paper is provided in ``papers/00_vanderwalt``.  Create a new
   directory ``papers/firstname_surname``, copy the example paper into it, and
@@ -42,7 +42,7 @@ paper:
 
 - Once you are ready to submit your paper, file a pull request on GitHub.
   **Please ensure that you file against the correct branch**--your branch
-  should be named 2016, and the pull-request should be against our 2016
+  should be named 2017, and the pull-request should be against our 2017
   branch.
 
 - Please do not modify any files outside of your paper directory.
@@ -80,7 +80,7 @@ These dates are the
 
 ## Review Criteria
 
-A small subcommittee of the SciPy 2016 organizing committee has created [this
+A small subcommittee of the SciPy 2017 organizing committee has created [this
 set of suggested review
 criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/review_criteria.md)
 to help guide authors and reviewers alike. Suggestions and amendments to these

--- a/review_criteria.md
+++ b/review_criteria.md
@@ -1,6 +1,6 @@
 # Suggested Review Criteria for SciPy Proceedings
 
-A small subcommittee of the SciPy 2016 organizing committee has created this 
+A small subcommittee of the SciPy 2017 organizing committee has created this 
 set of suggested review criteria
 to help guide authors and reviewers alike. Suggestions and amendments to these 
 review criteria are enthusiastically welcomed via discussion or pull request.

--- a/reviews/invite-reviewer.txt.in
+++ b/reviews/invite-reviewer.txt.in
@@ -1,7 +1,7 @@
 Hello {{ reviewer }}!
 
-The 2016 Scientific Computing with Python Conference
-(http://scipy2016.scipy.org) is fast approaching, and so too is the deadline
+The 2017 Scientific Computing with Python Conference
+(http://scipy2017.scipy.org) is fast approaching, and so too is the deadline
 for proceedings submissions (May 16th) and consequently the start of the
 review process.  
 
@@ -21,5 +21,5 @@ with any other community members who you think we should consider inviting to
 review.  
 
 Yours Truly, 
-Your SciPy 2016 Proceedings co-chairs,
+Your SciPy 2017 Proceedings co-chairs,
 Scott Rostrup and Sebastian Benthall

--- a/scipy_proc.json
+++ b/scipy_proc.json
@@ -1,14 +1,14 @@
 {
   "proceedings": {
-     "citation_key": "proc-scipy-2016",
+     "citation_key": "proc-scipy-2017",
      "title": {
        "acronym": "SciPy",
        "conference": "Python in Science Conference",
        "ordinal": "15th",
-       "short": "PROC. OF THE 15th PYTHON IN SCIENCE CONF. (SCIPY 2016)",
+       "short": "PROC. OF THE 15th PYTHON IN SCIENCE CONF. (SCIPY 2017)",
        "full": "Proceedings of the 15th Python in Science Conference"
      },
-     "year": "2016",
+     "year": "2017",
      "editor": [
         "Stéfan van der Walt",
         "Jarrod Millman"


### PR DESCRIPTION
@katyhuff mentioned this needed to be done, should have gotten everything. 

Also unless new content is addressed a simple find and replace can work for 2017 → 2018 next year (because there were no conflicting instances of 2017).