### PR TITLE
explicitly declare encoding on file reads and writes

### DIFF
--- a/publisher/build_paper.py
+++ b/publisher/build_paper.py
@@ -83,7 +83,7 @@ def rst2tex(in_path, out_path):
         raise RuntimeError("Found more than one input .rst--not sure which "
                            "one to use.")
 
-    with io.open(rst, mode='r') as f:
+    with io.open(rst, mode='r', encoding='utf-8') as f:
         content = header + f.read()
     
     tex = dc.publish_string(source=content, writer=writer,

--- a/publisher/build_papers.py
+++ b/publisher/build_papers.py
@@ -33,7 +33,7 @@ def paper_stats(paper_id, start):
 
     print('"%s" from p. %s to %s' % (paper_id, start, stop))
 
-    with io.open(os.path.join(output_dir, paper_id, 'page_numbers.tex'), 'w') as f:
+    with io.open(os.path.join(output_dir, paper_id, 'page_numbers.tex'), 'w', encoding='utf-8') as f:
         f.write('\setcounter{page}{%s}' % start)
 
     # Build table of contents

--- a/publisher/build_template.py
+++ b/publisher/build_template.py
@@ -26,10 +26,10 @@ class TeXTemplate(tempita.Template):
 def _from_template(tmpl_basename, config, use_html=True):
     tmpl = os.path.join(template_dir, tmpl_basename + '.tmpl')
     if use_html:
-        with io.open(tmpl, mode='r') as f:
+        with io.open(tmpl, mode='r', encoding='utf-8') as f:
             template = tempita.HTMLTemplate(f.read())
     else:
-        with io.open(tmpl, mode='r') as f:
+        with io.open(tmpl, mode='r', encoding='utf-8') as f:
             template = TeXTemplate(f.read())
     return template.substitute(config)
 
@@ -40,7 +40,7 @@ def from_template(tmpl_basename, config, dest_fn):
     outfile = _from_template(tmpl_basename, config, use_html=use_html)
     outname = os.path.join(build_dir, extension, dest_fn)
 
-    with io.open(outname, mode='w') as f:
+    with io.open(outname, mode='w', encoding='utf-8') as f:
         f.write(outfile)
 
 def bib_from_tmpl(bib_type, config, target):
@@ -66,7 +66,7 @@ def html_from_tmpl(src, config, target):
     dest_fn = os.path.join(html_dir, target + '.html')
     extension = os.path.splitext(dest_fn)[1][1:]
     outname = os.path.join(build_dir, extension, dest_fn)
-    with io.open(outname, mode='w') as f:
+    with io.open(outname, mode='w', encoding='utf-8') as f:
         f.write(outfile)
 
 if __name__ == "__main__":

--- a/publisher/conf.py
+++ b/publisher/conf.py
@@ -19,7 +19,7 @@ toc_conf      = os.path.join(build_dir, 'toc.json')
 proc_conf     = os.path.join(work_dir,'../scipy_proc.json')
 
 if os.path.isfile(toc_list):
-    with io.open(toc_list) as f:
+    with io.open(toc_list, 'r', encoding='utf-8') as f:
         dirs = f.read().splitlines()
 else:
     dirs = sorted([os.path.basename(d)


### PR DESCRIPTION
This doesn't do anything to change binary files, but I tried to exhaustively find anywhere the code is reading or writing a file using the default encoding and ensure that it's instead going to follow utf-8. 

That should address the ascii codec problems that people are dealing with.

Because this should directly address our build issues on the server I'm going to merge this immediately. 