### PR TITLE
Improve `scipy.sty` (no curly quotes in code, more math symbols)

### DIFF
--- a/publisher/_static/scipy.sty
+++ b/publisher/_static/scipy.sty
@@ -71,14 +71,17 @@
 \usepackage{fancyvrb}
 
 % Make single quotes non-curly in inline literal text (\texttt)
-% and in code-block directives (which use Pygments; patch Pygments macro)
+% and in code-block directives (which use Pygments; patch Pygments macro).
+% Also fix backtick in inline literal text.
 \AtBeginDocument{%
   \let\scipyoriginaltexttt\texttt
   \def\texttt#1{%
     \begingroup
     \scantokens{%
 	  \catcode`\'=\active
+	  \catcode`\`=\active
 	  \let'\textquotesingle
+	  \let`\textasciigrave
 	  \scipyoriginaltexttt{#1}\noexpand}%
     \endgroup}%
   \def\PYZsq{\textquotesingle}%

--- a/publisher/_static/scipy.sty
+++ b/publisher/_static/scipy.sty
@@ -19,6 +19,7 @@
 % Provide AMS mathematical commands such as "align"
 \usepackage{amsmath}
 \usepackage{amsfonts}
+\usepackage{amssymb}
 \usepackage{bm}
 
 % Define colours for hyperref
@@ -64,4 +65,21 @@
 \setlength{\tablewidth}{\linewidth}
 
 % Packages required for code highlighting
+% textcomp and upquote make single quotes non-curly in literal blocks
+\usepackage{textcomp}
+\usepackage{upquote}
 \usepackage{fancyvrb}
+
+% Make single quotes non-curly in inline literal text (\texttt)
+% and in code-block directives (which use Pygments; patch Pygments macro)
+\AtBeginDocument{%
+  \let\scipyoriginaltexttt\texttt
+  \def\texttt#1{%
+    \begingroup
+    \scantokens{%
+	  \catcode`\'=\active
+	  \let'\textquotesingle
+	  \scipyoriginaltexttt{#1}\noexpand}%
+    \endgroup}%
+  \def\PYZsq{\textquotesingle}%
+}


### PR DESCRIPTION
This improves `scipy.sty` by making sure all single quotation marks in code are not curly, and thus both appear and also copy correctly. It also adds the `amssymb` package to provide some additional math symbols. I added some custom LaTeX in my paper submission (#285) to accomplish this; if `scipy.sty` is improved, then that custom LaTeX would no longer be necessary.

