### PR TITLE
Fix : allows more than two editors on copyright page

### DIFF
--- a/publisher/_templates/copyright.tex.tmpl
+++ b/publisher/_templates/copyright.tex.tmpl
@@ -18,7 +18,7 @@
 Edited by {{if len(proceedings['editor']) <=2:}}
   {{' and '.join(proceedings['editor'])}}%
 {{else}}
-  {{', '.join(authlist[:-1] + ['and ' + authlist[-1],])}}%
+  {{', '.join(proceedings['editor'][:-1] + ['and ' + proceedings['editor'][-1],])}}%
 {{endif}}.
 
 \bigskip


### PR DESCRIPTION
This PR corrects two keyword arguments in the template file in `_templates/copyright.tex.tmpl` to match the metadata we currently store in `scipy_proc.json`.