### PR TITLE
change build_papers to build papers in the same directory that ./make_paper.sh did for path consistency

### DIFF
--- a/publisher/build_papers.py
+++ b/publisher/build_papers.py
@@ -18,6 +18,7 @@ pdf_dir    = conf.pdf_dir
 toc_conf   = conf.toc_conf
 proc_conf  = conf.proc_conf
 dirs       = conf.dirs
+papers_dir = conf.papers_dir
 
 
 def paper_stats(paper_id, start):
@@ -50,12 +51,18 @@ if __name__ == "__main__":
 
     options.mkdir_p(pdf_dir)
     for paper_id in dirs:
+        currdir = os.getcwd()
+        basedir = os.path.join(os.path.dirname(__file__), '..')
+        os.chdir(basedir)
         build_paper(paper_id)
+        os.chdir(currdir)
 
         stats, start = paper_stats(paper_id, start + 1)
         toc_entries.append(stats)
 
+        os.chdir(basedir)
         build_paper(paper_id)
+        os.chdir(currdir)
 
         src_pdf = os.path.join(output_dir, paper_id, 'paper.pdf')
         dest_pdf = os.path.join(pdf_dir, paper_id+'.pdf')


### PR DESCRIPTION
A bug arose related to including files and relative paths in #283 when running `make proceedings-html`. 

This arose in part because of the working directory from which the `build_paper` command was run when using `/make_paper.sh`. This hackily normalises that by changing the directory only for the purposes of running that command.

Thanks to @jhamrick for quick thinking on this one.

I'm going to merge this quickly so that I can make the current proceedings now.