### PR TITLE
FIX : updates "15th" to "16th" for conference ordinal

### DIFF
--- a/scipy_proc.json
+++ b/scipy_proc.json
@@ -4,9 +4,9 @@
      "title": {
        "acronym": "SciPy",
        "conference": "Python in Science Conference",
-       "ordinal": "15th",
-       "short": "PROC. OF THE 15th PYTHON IN SCIENCE CONF. (SCIPY 2017)",
-       "full": "Proceedings of the 15th Python in Science Conference"
+       "ordinal": "16th",
+       "short": "PROC. OF THE 16th PYTHON IN SCIENCE CONF. (SCIPY 2017)",
+       "full": "Proceedings of the 16th Python in Science Conference"
      },
      "year": "2017",
      "editor": [


### PR DESCRIPTION
Updates the ordinal in scipy_proc.json; closes #316. Thanks to @narendramukherjee for reporting the :bug: !