### PR TITLE
add zip command to Makefile to ease deployment

### DIFF
--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -5,7 +5,7 @@ PDFDIR = _build/pdfs
 PAPERDIR = ../output
 TEMPLATES = _templates
 STATIC = _static
-YEARDIR = scipy2017
+YEARDIR = scipy`date "+%Y"`
 ZIPNAME = camera_ready_draft_proceedings.zip
 
 BUILDTMPL = ./build_template.py
@@ -46,9 +46,11 @@ html:
 	python build_html.py
 	-convert $(STATIC)/logo.png -resize x100 $(HTMLDIR)/logo.png
 
+html-zip: html
+	cp -r $(HTMLDIR) $(YEARDIR)
+	zip -r $(ZIPNAME) $(YEARDIR) 
+	rm -rf $(YEARDIR)
+
 proceedings-html: proceedings html
 
-proceedings-html-zip: proceedings-html
-	cp -r $(HTMLDIR) $(YEARDIR)
-	zip -r camera_ready_draft_proceedings.zip $(YEARDIR)
-	rm -rf $(YEARDIR)
+proceedings-html-zip: proceedings html-zip

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -42,9 +42,11 @@ proceedings: front-pdf papers $(TEXDIR)/proceedings.tex
 	($(TEX2PDF) proceedings 1>/dev/null)
 	cp $(TEXDIR)/proceedings.pdf $(PDFDIR)/proceedings.pdf 
 
-proceedings-html: proceedings
+html: 
 	python build_html.py
 	-convert $(STATIC)/logo.png -resize x100 $(HTMLDIR)/logo.png
+
+proceedings-html: proceedings html
 
 proceedings-html-zip: proceedings-html
 	cp -r $(HTMLDIR) $(YEARDIR)

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -5,6 +5,8 @@ PDFDIR = _build/pdfs
 PAPERDIR = ../output
 TEMPLATES = _templates
 STATIC = _static
+YEARDIR = scipy2017
+ZIPNAME = camera_ready_draft_proceedings.zip
 
 BUILDTMPL = ./build_template.py
 TEX2PDF := cd $(TEXDIR) && pdflatex -interaction=batchmode
@@ -43,3 +45,8 @@ proceedings: front-pdf papers $(TEXDIR)/proceedings.tex
 proceedings-html: proceedings
 	python build_html.py
 	-convert $(STATIC)/logo.png -resize x100 $(HTMLDIR)/logo.png
+
+proceedings-html-zip: proceedings-html
+	cp -r $(HTMLDIR) $(YEARDIR)
+	zip -r camera_ready_draft_proceedings.zip $(YEARDIR)
+	rm -rf $(YEARDIR)


### PR DESCRIPTION
Primarily this just makes it possible to zip up the html directory 

This adds two variables (name of zip file and a directory to be the base directory when the zipfile is unpacked) that are compatible with the way that the http://conference.scipy.org/proceedings site likes to have things named & a name for the zip file.

It will need to be updated just like any other manually specified string relevant to the date. 

But this should avoid the issues that came up a few times when I was trying to build it manually before the conference. 

