### PR TITLE
Better nav

### DIFF
--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -50,7 +50,7 @@ html-zip: html
 	cp -r $(HTMLDIR) $(YEARDIR)
 	zip -r $(ZIPNAME) $(YEARDIR) 
 	rm -rf $(YEARDIR)
-
+	
 proceedings-html: proceedings html
 
 proceedings-html-zip: proceedings html-zip

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -7,6 +7,7 @@ TEMPLATES = _templates
 STATIC = _static
 YEARDIR = scipy`date "+%Y"`
 ZIPNAME = camera_ready_draft_proceedings.zip
+LINKFILE = proc_links.js
 
 BUILDTMPL = ./build_template.py
 TEX2PDF := cd $(TEXDIR) && pdflatex -interaction=batchmode

--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -49,9 +49,10 @@ html:
 
 html-zip: html
 	cp -r $(HTMLDIR) $(YEARDIR)
-	zip -r $(ZIPNAME) $(YEARDIR) 
-	rm -rf $(YEARDIR)
-	
+	cp -r $(STATIC)/$(LINKFILE) $(LINKFILE)
+	zip -r $(ZIPNAME) $(YEARDIR) $(LINKFILE)
+	rm -rf $(YEARDIR) $(LINKFILE)
+
 proceedings-html: proceedings html
 
 proceedings-html-zip: proceedings html-zip

--- a/publisher/_static/proc_links.js
+++ b/publisher/_static/proc_links.js
@@ -1,5 +1,5 @@
 function proc_versions() {
-   var versions = range(2017, 2008)
+   var versions = range('2017', '2008')
    var proc_url = 'http://conference.scipy.org/proceedings/scipy';
    document.write('<ul id="navibar">');
 
@@ -11,38 +11,50 @@ function proc_versions() {
 
    document.write('</ul>');
 }
+
+// range(start, end, step) 
+// provides a range of integers or strings, depending on the type of input provided.
+// If you input strings they will be converted to integers for the iteration logic to work.
+// start: Int or string, first element to include in output
+// end: Int or string, last element to include in output
+// step: Int, amount and direction the array will be stepped through
 var range = function(start, end, step) {
-    var range = [];
-    var typeofStart = typeof start;
-    var typeofEnd = typeof end;
+  var range = [];
+  var typeOfStart = typeof start;
+  var typeOfEnd = typeof end;
 
-    if (step === 0) {
-        throw TypeError("Step cannot be zero.");
+  if (typeOfStart == "undefined" || typeOfEnd == "undefined") {
+    throw TypeError("Must pass start and end arguments.");
+  } else if (typeOfStart != typeOfEnd) {
+    throw TypeError("Start and end arguments must be of same type.");
+  }
+  if (typeOfStart == "string"){ 
+    start = parseInt(start)
+    end = parseInt(end)
+  } 
+  
+  if (step === 0) {
+    throw TypeError("Step cannot be zero.");
+  }
+  typeof step == "undefined" && (step = 1);
+
+  if (end < start) {
+    step = -step;
+  }
+
+  if (typeOfStart == "number") {
+    while (step > 0 ? end >= start : end <= start) {
+      range.push(start);
+      start += step;
     }
-
-    if (typeofStart == "undefined" || typeofEnd == "undefined") {
-        throw TypeError("Must pass start and end arguments.");
-    } else if (typeofStart != typeofEnd) {
-        throw TypeError("Start and end arguments must be of same type.");
-    }
-
-    typeof step == "undefined" && (step = 1);
-
-    if (end < start) {
-        step = -step;
-    }
-
-    if (typeofStart == "number") {
-
-        while (step > 0 ? end >= start : end <= start) {
-            range.push(start);
-            start += step;
-        }
-
-    } else {
-        throw TypeError("Only number types are supported");
-    }
-
-    return range;
-
+  } else if (typeOfStart == "string") {
+      while (step > 0 ? end >= start : end <= start) {
+        range.push(start.toString());
+        start += step;
+      }
+  } else {
+    throw TypeError("Only number and string types are supported");
+  }
+  
+  return range;
 }

--- a/publisher/_static/proc_links.js
+++ b/publisher/_static/proc_links.js
@@ -1,5 +1,5 @@
 function proc_versions() {
-   var versions = ['2011', '2010', '2009', '2008'];
+   var versions = range(2017, 2008)
    var proc_url = 'http://conference.scipy.org/proceedings/scipy';
    document.write('<ul id="navibar">');
 
@@ -10,4 +10,39 @@ function proc_versions() {
    }
 
    document.write('</ul>');
+}
+var range = function(start, end, step) {
+    var range = [];
+    var typeofStart = typeof start;
+    var typeofEnd = typeof end;
+
+    if (step === 0) {
+        throw TypeError("Step cannot be zero.");
+    }
+
+    if (typeofStart == "undefined" || typeofEnd == "undefined") {
+        throw TypeError("Must pass start and end arguments.");
+    } else if (typeofStart != typeofEnd) {
+        throw TypeError("Start and end arguments must be of same type.");
+    }
+
+    typeof step == "undefined" && (step = 1);
+
+    if (end < start) {
+        step = -step;
+    }
+
+    if (typeofStart == "number") {
+
+        while (step > 0 ? end >= start : end <= start) {
+            range.push(start);
+            start += step;
+        }
+
+    } else {
+        throw TypeError("Only number types are supported");
+    }
+
+    return range;
+
 }

--- a/publisher/_templates/header.html.tmpl
+++ b/publisher/_templates/header.html.tmpl
@@ -3,7 +3,7 @@
     <meta content="text/html; charset=utf-8" http-equiv="content-type">
     <title>{{html_quote(proceedings['title']['short']) | html}}</title>
     <link rel="stylesheet" href="scipy-proc.css" type="text/css"/>
-    <script type="text/javascript" src="http://conference.scipy.org/proceedings/proc_links.js"></script>
+    <script type="text/javascript" src="../proc_links.js"></script>
     <script type="text/javascript" src="http://conference.scipy.org/proceedings/google_analytics.js"></script>
 {{if 'article' in locals().keys()}}
     <meta name="citation_title" content="{{article['title']}}"/> 

--- a/publisher/build_html.py
+++ b/publisher/build_html.py
@@ -13,6 +13,8 @@ config = get_config()
 mkdir_p(bib_dir)
 for file in glob.glob(os.path.join(static_dir,'*.css')):
     shutil.copy(file, html_dir)
+for file in glob.glob(os.path.join(static_dir,'*.js')):
+    shutil.copy(file, os.path.join(html_dir,'..'))
 html_pdfs = os.path.join(html_dir, 'pdfs')
 mkdir_p(html_pdfs)
 for file in glob.glob(os.path.join(pdf_dir,'*.pdf')):
@@ -25,7 +27,7 @@ bib_from_tmpl('proceedings', config, citation_key)
 proc_dict = deepcopy(config)
 proc_dict.update({
     'pdf': 'pdfs/proceedings.pdf',
-    'bibtex': 'bib/' + citation_key
+    'bibtex': 'bib/' + citation_key + '.bib'
     })
 
 for dest_fn in ['index', 'organization', 'students']:
@@ -39,4 +41,4 @@ for article in config['toc']:
         'bibtex': 'bib/'+article['paper_id']+'.bib',
         })
     bib_from_tmpl('article', art_dict, article['paper_id'])
-    html_from_tmpl('article.html',art_dict, article['paper_id'])
+    html_from_tmpl('article.html', art_dict, article['paper_id'])


### PR DESCRIPTION
This will avoid many of the issues that currently plague the proceedings website. It should overwrite whatever file is currently present in the directory in which it's unzipped (meaning we can update it in our repo rather than relying on the current value of https://conference.scipy.org/proceedings/proc_links.js. 

This has been already been rebased on #320.