### PR TITLE
update video links for all authors to SciPy2017 videos, remove links to non SciPy2017 videos

### DIFF
--- a/papers/horea-ioan_ioanas/paper.rst
+++ b/papers/horea-ioan_ioanas/paper.rst
@@ -12,6 +12,7 @@
 :institution: Institute for Biomedical Engineering, ETH and University of Zurich
 
 :bibliography: mybib
+:video: https://youtu.be/yDBu_wSyw-g
 
 
 LabbookDB: A Wet-Work-Tracking Database Application Framework

--- a/papers/ingo_heimbach/paper.rst
+++ b/papers/ingo_heimbach/paper.rst
@@ -75,8 +75,6 @@
 :email: r.jones@fz-juelich.de
 :institution: PGI-1 and PGI/JCNS-TA, Forschungszentrum Jülich, D-52425 Jülich, Germany
 
-:video: https://pgi-jcns.fz-juelich.de/pub/media/pymoldyn_algorithms.mp4
-
 
 #################################################################################################
 pyMolDyn: Identification, structure, and properties of cavities in condensed matter and molecules

--- a/papers/jaime_arias/paper.rst
+++ b/papers/jaime_arias/paper.rst
@@ -37,6 +37,7 @@
 :equal-contributor:
 
 :bibliography: biblio
+:video: https://youtu.be/Usyvds1o4lQ
 
 --------------------------------------------------------------------------------------------------------------------
 PyHRF: A Python Library for the Analysis of fMRI Data Based on Local Estimation of the Hemodynamic Response Function

--- a/papers/joseph_hellerstein/scisheets.rst
+++ b/papers/joseph_hellerstein/scisheets.rst
@@ -7,6 +7,8 @@
 :institution: eScience Institute and School of Computer Science, University of Washington. This work was made possible by the Moore/Sloan Data Science Environments Project at the University of Washington supported by grants from the Gordon and Betty Moore Foundation (Award #3835) and the Alfred P. Sloan Foundation (Award #2013-10-29).
 :corresponding:
 
+:video: https://www.youtube.com/watch?v=2-qCCR5r01A
+
 ---------------------------------------------------------------------------------
 SciSheets: Providing the Power of Programming With The Simplicity of Spreadsheets
 ---------------------------------------------------------------------------------

--- a/papers/klaus_greff/paper.rst
+++ b/papers/klaus_greff/paper.rst
@@ -25,7 +25,7 @@
 :bibliography: sacred
 
 
-.. .:video: http://www.youtube.com/watch?v=dhRUe-gz690
+:video: https://www.youtube.com/watch?v=qqg7RO0o1OE 
 
 ----------------------------------------------------
 The Sacred Infrastructure for Computational Research

--- a/papers/michael_beyeler/michael_beyeler.rst
+++ b/papers/michael_beyeler/michael_beyeler.rst
@@ -20,7 +20,7 @@
 
 :bibliography: bibliography
 
-:video: https://github.com/uwescience/pulse2percept
+:video: https://youtu.be/KxsNAa-P2X4
 
 
 --------------------------------------------------------------------

--- a/papers/michael_lange/michael_lange.rst
+++ b/papers/michael_lange/michael_lange.rst
@@ -27,6 +27,8 @@
 :email: g.gorman@imperial.ac.uk
 :institution: Imperial College London
 
+:video: https://youtu.be/KinmqFTEs94
+
 ---------------------------------------------------------------
 Optimised finite difference computation from symbolic equations
 ---------------------------------------------------------------

--- a/papers/narendra_mukherjee/00_vanderwalt.rst
+++ b/papers/narendra_mukherjee/00_vanderwalt.rst
@@ -14,7 +14,6 @@
 
 :bibliography: mybib
 
-:video: https://github.com/narendramukherjee/blech_clust
 
 --------------------------------------------------------------------------------------------------------------------
 Python meets systems neuroscience: affordable, scalable and open-source electrophysiology in awake, behaving rodents

--- a/papers/oleksandr_pavlyk/optimizations.rst
+++ b/papers/oleksandr_pavlyk/optimizations.rst
@@ -41,7 +41,6 @@
 
 :year: 2017
 
-:video: http://www.youtube.com/watch?v=
 
 -------------------------------------------------------
 Accelerating Scientific Python with Intel Optimizations

--- a/papers/will_barnes/paper.rst
+++ b/papers/will_barnes/paper.rst
@@ -9,7 +9,7 @@
 
 :bibliography: references
 
-:video: http://youtube.com/the-video-of-my-talk.html
+:video: https://youtu.be/79ledxbnrPU 
 
 ----------------------------------------------------------
 ChiantiPy: a Python package for Astrophysical Spectroscopy

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -44,6 +44,7 @@ class Translator(LaTeXTranslator):
         self.keywords = ''
         self.table_caption = []
         self.video_url = ''
+        self.latex_video_url = ''
         self.bibliography = ''
 
         # This gets read by the underlying docutils implementation.
@@ -108,7 +109,8 @@ class Translator(LaTeXTranslator):
         elif self.current_field == 'copyright_holder':
             self.copyright_holder = text
         elif self.current_field == 'video':
-            self.video_url = text
+            self.latex_video_url = text
+            self.video_url = node.astext() if text else ''
         elif self.current_field == 'bibliography':
             self.bibtex = ['alphaurl', text]
             self._use_latex_citations = True
@@ -236,10 +238,10 @@ class Translator(LaTeXTranslator):
 
         ## Set up title and page headers
 
-        if not self.video_url:
+        if not self.latex_video_url:
             video_template = ''
         else:
-            video_template = '\\\\\\vspace{5mm}\\tt\\url{%s}\\vspace{-5mm}' % self.video_url
+            video_template = '\\\\\\vspace{5mm}\\tt\\url{%s}\\vspace{-5mm}' % self.latex_video_url
 
         title_template = r'\newcounter{footnotecounter}' \
                 r'\title{%s}\author{%s' \


### PR DESCRIPTION
This is one of the last steps we need to complete before we can release the papers. 

I did this by hand, so there could be errors. 

But, I think all of the remaining papers that don't have video links (after this PR is merged) are papers associated with poster presentations (and therefore have no video).