### PR TITLE
FIX: adds 'l' to 'html' for conference paper web page

### DIFF
--- a/publisher/xreftools.py
+++ b/publisher/xreftools.py
@@ -154,7 +154,7 @@ class XrefMeta:
         The "paper_id" is pulled out of the toc, and is literally whatever the
         author named the folder that they put their paper in
         """
-        page = paper_id + '.htm'
+        page = paper_id + '.html'
         return '/'.join([self.proceedings_url(), page])
 
     def proceedings_url(self):


### PR DESCRIPTION
There is a typo in the function that generates the paper endpoints for the DOI metadata which currently omits the "l" in "html".