### PR TITLE
NEW: script to autogenerate DOI announcement emails

### DIFF
--- a/publisher/mail/_mailer.py
+++ b/publisher/mail/_mailer.py
@@ -14,6 +14,11 @@ from build_template import _from_template
 args = None
 password = None
 
+def author_greeting(names):
+    if len(names) == 1:
+        return names[0]
+    else:
+        return ', '.join(names[:-1]) + ', and ' + names[-1]
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Invite reviewers.")

--- a/publisher/mail/mail_dois.py
+++ b/publisher/mail/mail_dois.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import os
+
+import _mailer as mailer
+from conf import work_dir, toc_conf, proc_conf
+import options
+
+args = mailer.parse_args()
+scipy_proc = options.cfg2dict(proc_conf)
+toc = options.cfg2dict(toc_conf)
+
+sender = scipy_proc['proceedings']['xref']['depositor_email']
+template = 'doi-notification.txt'
+template_data = scipy_proc.copy()
+template_data['proceedings']['editor_email'] = ', '.join(template_data['proceedings']['editor_email'])
+
+for paper in toc['toc']:
+
+    template_data.update(paper)
+    recipients = ','.join(template_data['author_email'])
+    template_data['author'] = mailer.author_greeting(template_data['author'])
+    template_data['author_email'] = ', '.join(template_data['author_email'])
+    template_data['committee'] = '\n  '.join(template_data['proceedings']['editor'])
+
+    mailer.send_template(sender, recipients, template, template_data)

--- a/publisher/mail/templates/doi-notification.txt.tmpl
+++ b/publisher/mail/templates/doi-notification.txt.tmpl
@@ -1,0 +1,14 @@
+From: {{proceedings['xref']['depositor_email'] | html}}
+Subject: Your {{proceedings['title']['acronym']}} {{proceedings['year']}} Paper DOI
+To: {{author_email | html}}
+Cc: {{proceedings['editor_email'] | html}}
+MIME-Version: 1.0
+Content-Type: text/plain
+
+Dear {{author}},
+
+Your paper from the {{proceedings['title']['ordinal']}} {{proceedings['title']['conference']}} titled “{{title}}” has been assigned the DOI {{doi}}. Please use this DOI when providing citations for your paper, following the guidelines here: https://www.crossref.org/display-guidelines/#full
+
+Yours,
+{{proceedings['xref']['depositor_name']}}, on behalf of:
+  {{committee}}

--- a/publisher/xreftools.py
+++ b/publisher/xreftools.py
@@ -19,7 +19,7 @@ import lxml.etree as xml
 from nameparser import HumanName
 import time
 
-from doitools import make_batch_id, make_doi
+from doitools import make_batch_id
 
 class XrefMeta:
 
@@ -111,7 +111,7 @@ class XrefMeta:
         noisbn = xml.SubElement(proceedings_metadata, 'noisbn', reason="simple_series") # Do not modify, unless someone has actually gone and gotten us an ISBN
         proceedings_doi_data = xml.SubElement(proceedings_metadata, 'doi_data')
         proceedings_doi = xml.SubElement(proceedings_doi_data, 'doi')
-        proceedings_doi.text = make_doi(self.scipy_entry["proceedings"]["xref"]["prefix"])
+        proceedings_doi.text = self.scipy_entry["proceedings"]["doi"]
         proceedings_resource = xml.SubElement(proceedings_doi_data, 'resource')
         proceedings_resource.text = self.proceedings_url()
 
@@ -140,7 +140,7 @@ class XrefMeta:
         last_page.text = str(entry['page']['stop'])
         paper_doi_data = xml.SubElement(paper, 'doi_data')
         paper_doi = xml.SubElement(paper_doi_data, 'doi')
-        paper_doi.text = make_doi(self.scipy_entry["proceedings"]["xref"]["prefix"])
+        paper_doi.text = entry['doi']
         paper_resource = xml.SubElement(paper_doi_data, 'resource')
         paper_resource.text = self.paper_url(entry['paper_id'])
 

--- a/scipy_proc.json
+++ b/scipy_proc.json
@@ -22,6 +22,12 @@
         "Dillon Niederhut",
         "M Pacer"
      ],
+     "editor_email": [
+         "katyhuff@gmail.com",
+         "dalippa@gmail.com",
+         "dniederhut@enthought.com",
+         "mpacer@berkeley.edu"
+     ],
      "volume": 3,
      "number": 1,
      "isbn": "value",


### PR DESCRIPTION
This PR modifies `build_papers` such that the generated DOIs end up in `toc.json` and `scipy_proc.json` whenever the proceedings for the conference are built. It adds a script that hooks into the existing email notification infrastructure, and fills in a simple template with authors, email addresses, and DOIs for each paper. The generated text looks like this:

```
From: dniederhut@enthought.com
Subject: Your SciPy 2017 Paper DOI
To: jj@rome.it, mark37@rome.it, millman@rome.it, brutus@rome.it
Cc: katyhuff@gmail.com, dalippa@gmail.com, dniederhut@enthought.com, mpacer@berkeley.edu
MIME-Version: 1.0
Content-Type: text/plain

Dear Gaius Caesar, Mark Anthony, Jarrod Millman, and Brutus,

Your paper from the 16th Python in Science Conference titled “A Numerical Perspective to Terraforming a Desert” has been assigned the DOI 10.25080/mbp-b27ba91-010. Please use this DOI when providing citations for your paper, following the guidelines here: https://www.crossref.org/display-guidelines/#full

Yours,
Dillon Niederhut, on behalf of:
  Katy Huff
  David Lippa
  Dillon Niederhut
  M Pacer
```

I haven't set up a dev gmail account to test the smtp parts of `_mailer.py`, so I don't know if this will actually send anything, but it will at least generate reasonable things to be cut and pasted. 