### PR TITLE
Fixing docutils 0.14 build issues: footnotes & code in captions

### DIFF
--- a/papers/00_vanderwalt/00_vanderwalt.rst
+++ b/papers/00_vanderwalt/00_vanderwalt.rst
@@ -97,6 +97,8 @@ Or a snippet from the above code, starting at the correct line number:
    for (int i = 0; i < 10; i++) {
        /* do something */
    }
+   
+Inline code looks like this: :code:`chunk of code`.
 
 Important Part
 --------------
@@ -151,7 +153,7 @@ pulvinar id metus.
 
 .. figure:: figure1.png
 
-   This is the caption. :label:`egfig`
+   This is the caption.:code:`chunk of code` inside of it. :label:`egfig` 
 
 .. figure:: figure1.png
    :align: center
@@ -159,6 +161,7 @@ pulvinar id metus.
 
    This is a wide figure, specified by adding "w" to the figclass.  It is also
    center aligned, by setting the align keyword (can be left, right or center).
+   This caption also has :code:`chunk of code`.
 
 .. figure:: figure1.png
    :scale: 20%
@@ -168,7 +171,7 @@ pulvinar id metus.
    bottom of the page, and failing that it will be placed inline or at the top.
    Note that for now, scale is relative to a completely arbitrary original
    reference size which might be the original size of your image - you probably
-   have to play with it. :label:`egfig2`
+   have to play with it.  :label:`egfig2`
 
 As you can see in Figures :ref:`egfig` and :ref:`egfig2`, this is how you reference auto-numbered
 figures.

--- a/publisher/build_paper.py
+++ b/publisher/build_paper.py
@@ -31,6 +31,7 @@ header = r'''
     \InputIfFileExists{page_numbers.tex}{}{}
     \newcommand*{\docutilsroleref}{\ref}
     \newcommand*{\docutilsrolelabel}{\label}
+    \newcommand*\DUrolecode[1]{#1}
     \providecommand*\DUrolecite[1]{\cite{#1}}
 
 .. |---| unicode:: U+2014  .. em dash, trimming surrounding whitespace

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -53,7 +53,6 @@ class Translator(LaTeXTranslator):
         self.bibtex = None
 
         self.abstract_in_progress = False
-        self.non_breaking_paragraph = False
 
         self.figure_type = 'figure'
         self.figure_alignment = 'left'
@@ -304,9 +303,6 @@ class Translator(LaTeXTranslator):
             self.out.append('\\begin{IEEEkeywords}')
             self.keywords = self.encode(node.astext())
 
-        elif self.non_breaking_paragraph:
-            self.non_breaking_paragraph = False
-
         else:
             if self.active_table.is_open():
                 self.out.append('\n')
@@ -370,8 +366,6 @@ class Translator(LaTeXTranslator):
         LaTeXTranslator.visit_footnote(self, node)
         self.out[-1] = self.out[-1].strip('%')
 
-        self.non_breaking_paragraph = True
-
     def visit_table(self, node):
         classes = node.attributes.get('classes', [])
         if 'w' in classes:
@@ -413,7 +407,6 @@ class Translator(LaTeXTranslator):
         LaTeXTranslator.depart_thead(self, node)
 
     def visit_literal_block(self, node):
-        self.non_breaking_paragraph = True
 
         if 'language' in node.attributes:
             # do highlighting
@@ -463,7 +456,6 @@ class Translator(LaTeXTranslator):
     def visit_PartMath(self, node):
         self.requirements['amsmath'] = '\\usepackage{amsmath}'
         self.out.append(mathEnv(node['latex'], node['label'], node['type']))
-        self.non_breaking_paragraph = True
         raise nodes.SkipNode
 
     def visit_PartLaTeX(self, node):

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -368,7 +368,7 @@ class Translator(LaTeXTranslator):
         # Work-around for a bug in docutils where
         # '%' is prepended to footnote text
         LaTeXTranslator.visit_footnote(self, node)
-        self.out[-1] = self.out[1].strip('%')
+        self.out[-1] = self.out[-1].strip('%')
 
         self.non_breaking_paragraph = True
 


### PR DESCRIPTION
Basically the problem was that `self.out` was a record of the whole document up until that point, and so rather than stripping the unnecessary `%` from the footnote that was being created (which was why the line was originally introduced in https://github.com/scipy-conference/scipy_proceedings/commit/7cb4c6a8f169b3667ba6326877cbb0bf98bd9556), it was replacing it with the second element of the complete document. 

In this case it was replacing it with the header, which was causing LaTeX to break when it tried to define commands more than once.

a debugging session with @stefanv and @Carreau helped me figure this one out