### PR TITLE
add doi example to 00_bibderwalt citation

### DIFF
--- a/papers/00_bibderwalt/00_bibderwalt.rst
+++ b/papers/00_bibderwalt/00_bibderwalt.rst
@@ -86,6 +86,37 @@ If you wish to have a block quote, you can just indent the text, as in
 
     When it is asked, What is the nature of all our reasonings concerning matter of fact? the proper answer seems to be, that they are founded on the relation of cause and effect. When again it is asked, What is the foundation of all our reasonings and conclusions concerning that relation? it may be replied in one word, experience. But if we still carry on our sifting humor, and ask, What is the foundation of all conclusions from experience? this implies a new question, which may be of more difficult solution and explication. :cite:`hume48`
 
+Dois in bibliographies
+++++++++++++++++++++++
+
+In order to include a doi in your bibliography, add the doi to your bibliography
+entry as a string. For example:
+
+.. code-block:: bibtex
+
+   @Book{hume48,
+     author =  "David Hume",
+     year =    "1748",
+     title =   "An enquiry concerning human understanding",
+     address =     "Indianapolis, IN",
+     publisher =   "Hackett",
+     doi = "10.1017/CBO9780511808432",
+   }
+
+
+If there are errors when adding it due to non-alphanumeric characters, see if
+wrapping the doi in ``\detokenize`` works to solve the issue.
+
+.. code-block:: bibtex
+
+   @Book{hume48,
+     author =  "David Hume",
+     year =    "1748",
+     title =   "An enquiry concerning human understanding",
+     address =     "Indianapolis, IN",
+     publisher =   "Hackett",
+     doi = \detokenize{10.1017/CBO9780511808432},
+   }
 
 Source code examples
 --------------------

--- a/papers/00_bibderwalt/mybib.bib
+++ b/papers/00_bibderwalt/mybib.bib
@@ -4,4 +4,5 @@
   title =   "An enquiry concerning human understanding",
   address =     "Indianapolis, IN",
   publisher =   "Hackett",
+  doi = "10.1017/CBO9780511808432",
 }

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -53,6 +53,7 @@ class Translator(LaTeXTranslator):
         self.bibtex = None
 
         self.abstract_in_progress = False
+        self.non_breaking_paragraph = False
 
         self.figure_type = 'figure'
         self.figure_alignment = 'left'
@@ -303,6 +304,9 @@ class Translator(LaTeXTranslator):
             self.out.append('\\begin{IEEEkeywords}')
             self.keywords = self.encode(node.astext())
 
+        elif self.non_breaking_paragraph:
+            self.non_breaking_paragraph = False
+
         else:
             if self.active_table.is_open():
                 self.out.append('\n')
@@ -366,6 +370,8 @@ class Translator(LaTeXTranslator):
         LaTeXTranslator.visit_footnote(self, node)
         self.out[-1] = self.out[-1].strip('%')
 
+        self.non_breaking_paragraph = True
+
     def visit_table(self, node):
         classes = node.attributes.get('classes', [])
         if 'w' in classes:
@@ -407,6 +413,7 @@ class Translator(LaTeXTranslator):
         LaTeXTranslator.depart_thead(self, node)
 
     def visit_literal_block(self, node):
+        self.non_breaking_paragraph = True
 
         if 'language' in node.attributes:
             # do highlighting
@@ -456,6 +463,7 @@ class Translator(LaTeXTranslator):
     def visit_PartMath(self, node):
         self.requirements['amsmath'] = '\\usepackage{amsmath}'
         self.out.append(mathEnv(node['latex'], node['label'], node['type']))
+        self.non_breaking_paragraph = True
         raise nodes.SkipNode
 
     def visit_PartLaTeX(self, node):


### PR DESCRIPTION
This creates a linked doi for the associated doi in the bibliography entry: at `http://dx.doi.org/<doi>`

So in this case, it is http://dx.doi.org/10.1017/CBO9780511808432. 

I also added "documentation" to the 00_bibderwalt example.

Also, I reverted 5dd888dd4fe72d9b168e33a05758bbf8f368c68e

`self.non_breaking_paragraph` isn't a docutils feature, but it is a custom feature we use in a super roundabout fashion. 

Basically we have an elif looking for  `self.non_breaking_paragraph` in `self.visit_paragraph()`. The only point of that elif is to preëmptively catch stuff before it had newlines added to it in https://github.com/scipy-conference/scipy_proceedings/blob/82253931a114463b31856f93169b5a65553eae3a/publisher/writer/__init__.py#L306-L310

There is probably a better way to implement this, but I can't think of it off the top of my head so I reverted my previous commit that had introduced issues with footnote spacing.