### PR TITLE
BUG: adds citation_journal_title meta tag

### DIFF
--- a/publisher/_templates/header.html.tmpl
+++ b/publisher/_templates/header.html.tmpl
@@ -6,12 +6,13 @@
     <script type="text/javascript" src="http://conference.scipy.org/proceedings/proc_links.js"></script>
     <script type="text/javascript" src="http://conference.scipy.org/proceedings/google_analytics.js"></script>
 {{if 'article' in locals().keys()}}
-    <meta name="citation_title" content="{{article['title']}}"/> 
+    <meta name="citation_title" content="{{article['title']}}"/>
     {{for auth in article['author']}}
     <meta name="citation_author" content="{{auth}}" />
     {{endfor}}
     <meta name="citation_publication_date" content="{{proceedings['year']}}" />
     <meta name="citation_conference_title" content="{{proceedings['title']['full']}}" />
+    <meta name="citation_journal_title" content="{{proceedings['title']['full']}}" />
     <meta name="citation_firstpage" content="{{article['page']['start']}}" />
     <meta name="citation_lastpage" content="{{article['page']['stop']}}" />
     <meta name="citation_pdf_url" content="http://conference.scipy.org/proceedings/scipy{{proceedings['year']}}/pdfs/{{article['paper_id']}}.pdf" />


### PR DESCRIPTION
It looks like google scholar may not be correctly indexing
papers by `<meta name=citation_conference_title>`. This adds
`<meta name=citation_journal_title>` with the same content.
Closes #299.