### PR TITLE
Update for 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,39 @@ If you are an *Author*, please see [Instructions-for-Authors](#Instructions-for-
 
 If you are a *Reviewer*, please see [Instructions-for-Reviewers](#Instructions-for-Reviewers).
 
+## Organising Principles
 
+Overall, we aim to combine the best principles of open source development and
+open academic publication processes.
 
+**All** communication between authors and reviewers should be civil. There are
+no exceptions to this rule.
 
+Authors submit papers through PRs, and reviewers review the papers through
+comments on PRs.
 
+Authors and reviewers are encouraged to work collaboratively to improve submissions
+throughout the review process, much like open source code-review.
 
+The purpose of collaborative review is primarily to improve the publication
+quality, not merely to vet and validate the content of the paper.
 
+Conversations occur in the open, allowing for transparency in this open review
+process. This holds authors and reviewers accountable and encourages civil
+communication practices.
 
+Reviewers are invited by the editors, but community members may volunteer to
+review papers that interest them.
 
+All the resulting papers have DOIs (making them easily citable) and are openly
+available.
 
+The build tools are built on open source tools (LaTeX, docutils, Python, ReST).
 
+The build tools have been developed by a variety of individuals and are managed
+via public, open source repositories (https://github.com/scipy-conference/scipy_proceedings and
+https://github.com/scipy-conference/procbuild), allowing anyone who wishes to
+adopt or extend these tools to do so easily.
 
 ## Timeline for 2018
 

--- a/README.md
+++ b/README.md
@@ -287,11 +287,11 @@ su -c `dnf install python-docutils texlive-collection-basic texlive-collection-f
 
 ## Build Server
 
-There will be a server online building the open pull requests 
-[here](http://zibi.bids.berkeley.edu:7001). You should be able to pull a built PDF 
-for review from there.
+There will be a server online building open pull requests at http://procbuild.scipy.org. 
 
-TODO: update server link
+Authors, you should check to ensure that your local builds match the papers built on this site. Please create an issue if they do not match.
+
+Reviewers: You should be able to pull a built PDF for review from there.
 
 ## For organizers
 

--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ In 2018, the Proceedings Co-Chairs are
 
 In addition to the following list, we break up the deadlines in the respective documents for authors and reviewers.
 
-- April 9th: Authors invited to submit full papers
-- May 14th: 1st Draft for Submission
-- May 14th – June 25th: Open Review Period
-- May 15th: Reviewers Assigned
-- June 11th: Initial Complete Review
-- June 25th: Final Recommendation and Comprehensive Review
-- July 2: Final Editorial Decisions for Proceedings Contents
-- July 9: Conference Ready Proceedings Published
+- April 10–12: Authors invited to submit full papers
+- May 21: 1st Draft for Submission
+- May 21–July 2: Open Review Period
+- May 22: Reviewers Assigned
+- June 18: Initial Complete Review
+- July 2: Final Recommendation and Comprehensive Review Deadlines
+- July 3: Final Editorial Decisions for Proceedings Contents Deadline
+- July 6-9: Time Window for Publishing Conference Ready Proceedings
 
 ## Instructions for Authors
 
@@ -151,9 +151,10 @@ have final say in whether to accept or reject a paper.
 
 ### Author Deadlines
 
-- May 14th: 1st Draft for Submission Deadline
-- May 14th – June 25th: Open Review Period 
-- July 2: Final Editorial Decisions for Proceedings Contents Deadline
+- April 10–12: Authors invited to submit full papers
+- May 21: 1st Draft for Submission Deadline
+- May 21–July 2: Open Review Period 
+- July 5: Final Editorial Decisions for Proceedings Contents Deadline
 
 ### General Information and Guidelines for Authors:
 
@@ -348,9 +349,9 @@ change in question, then that change should be requested and made before the
 
 ### Reviewer Deadlines
 
-- 1st Draft of Proceedings Submission Due: 5/14/2018	
-- Initial Complete Review Deadline:	6/11/2018
-- Final Recommendation Deadline: 6/25/2018
+- May 21: 1st Draft of Proceedings Submission Due: 5/14/2018	
+- June 18: Initial Complete Review Deadline:	6/11/2018
+- July 2: Final Recommendation Deadline: 6/25/2018
 
 ### Reviewer Workflow
 
@@ -420,6 +421,13 @@ Reviewers: You should be able to pull a built PDF for review from there.
 To information about how to manage the whole proceedings, please see
 `publisher/README.md` and `publisher/Makefile`.
 
+#### Publisher Deadlines
+
+- April 10–12: Authors invited to submit full papers
+- May 21–July 2: Open Review Period
+    - The [build server](#build-server) should be maintained throughout the Open Review Period.
+- July 6-9: Time Window for Publishing Conference Ready Proceedings
+
 ### Instructions for Editors
 
 As reviewers review papers, editors should apply **labels** to the PR to flag the 
@@ -431,3 +439,11 @@ current state of the review process.
 
 Editors should come to a final 'ready', 'unready' decision before the **Final Editorial Decisions for Proceedings Contents** deadline.
 
+#### Editor Deadlines
+
+- April 10–12: Authors invited to submit full papers
+- May 21–July 2: Open Review Period
+- May 22: Reviewers Assigned
+- June 18: Initial Complete Review  
+    - Editors should verify that reviews have been completed
+- July 3: Final Editorial Decisions for Proceedings Contents Deadline

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ If you are a *Reviewer*, please see [Instructions-for-Reviewers](#Instructions-f
 
 
 
+## Timeline for 2018
+
+In addition to the following list, we break up the deadlines in the respective documents for authors and reviewers.
+
+- April 9th: Authors invited to submit full papers
+- May 14th: 1st Draft for Submission
+- May 14th – June 25th: Open Review Period
+- May 15th: Reviewers Assigned
+- June 11th: Initial Complete Review
+- June 25th: Final Recommendation and Comprehensive Review
+- July 2: Final Editorial Decisions for Proceedings Contents
+- July 9: Conference Ready Proceedings Published
 
 ## Instructions for Authors
 
@@ -40,6 +52,12 @@ the PR's comment sections. It is important to remember in this case that we expe
 In the event that the authors and reviewers find
 themselves unable to resolve a disagreement about a recommendation, they should
 alert a Proceedings Co-Chair to this situation.
+
+### Author Deadlines
+
+- May 14th: 1st Draft for Submission Deadline
+- May 14th – June 25th: Open Review Period 
+- July 2: Final Editorial Decisions for Proceedings Contents Deadline
 
 ### General Information and Guidelines for Authors:
 
@@ -196,6 +214,11 @@ outstanding issues remaining. As a heuristic, if you think the paper should not
 be in the proceedings unless the authors make the change in question, then that 
 change should be made before the *Final Recommendation Deadline*.
 
+### Reviewer Deadlines
+
+- 1st Draft of Proceedings Submission Due: 5/14/2018	
+- Initial Complete Review Deadline:	6/11/2018
+- Final Recommendation Deadline: 6/25/2018
 
 ### Reviewer Workflow
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ have final say in whether to accept or reject a paper.
         - Label figures, equations and tables
         - Use math markup
         - Include code snippets
-    - `00_bibderwalt` also shows how to use a bib file for citations
+    - `00_bibderwalt` shows how to use a bib file for citations.
+- All citations that have DOIs should include those DOIs in the paper's 
+  references section, see [`mybib.bib`](./papers/00_bibderwalt/mybib.bib).
 - All figures and tables should have captions.
 - Figures and tables should be positioned inline, close to their explanatory text.
 - License conditions on images and figures must be respected (Creative Commons,
@@ -197,14 +199,19 @@ into:
 git clone https://github.com/mpacer/scipy_proceedings
 ```
 
+#### Author workflow steps
+
 1. Get a local copy of the `scipy_proceedings` repo.
 2. Update your local copy of the `scipy_proceedings` repo.
-3. Create a new branch for your paper based off the latest `2018` branch.
+3. [Create a new branch](Creating a new branch based off-of-`2018`) for your paper based off the latest `2018` branch.
     - If you submit multiple papers, you will need a new branch for each.
-4. Set up your environment.
-5. Write your paper, commit changes, and build your paper.
-    - If you want to alter the build system, create a separate PR against `dev`.
-6. Repeat step 6, while also responding to reviewer feedback.
+4. [Set up your environment](#setting-up-your-environment).
+5. [Write your paper](#write-your-paper), [commit changes](#commit-your-changes), and [build your paper](#build-your-paper) 
+6. [Create a PR](#create-a-paper-pr) or [push changes to your PR's branch](#push-your-changes) and [check your paper](#check-your-paper) on http://procbuild.scipy.org.
+    - If you want to alter the build system, do not include it in your 
+      submission's PR, create a separate PR against `dev` 
+      ([see below](creating-build-system-prs) for more details).
+7. Repeat steps 5 and 6, while also responding to reviewer feedback.
 
 #### Getting a local copy of the scipy_proceedings repo 
 
@@ -260,12 +267,22 @@ git push --set-upstream origin <your_branch_name>
 - Copy an example paper into your directory.
     - You must have only one reST file in the top level of `<your_directory_name>`.
 - As you make changes to your paper, commit those changes in discrete chunks. 
-- Do not modify any files outside of your paper directory.
+
+#### Commit your changes
+
+- Commit any changes inside the `paper/<your_directory_name>`
+- When you push your commits to your PR's branch, the paper will be autobuilt 
+- Do not commit any changes to files outside of your paper directory.
+
+If you want to change the way the build system works, we use a separate
+submission procedure ([see below](creating-build-system-prs)).
 
 #### Build your paper
 
 - Run `./make_paper.sh papers/firstname_surname` to make a PDF of your paper 
 - Check the output in `output/<your_directory_name>/paper.pdf`.
+- Check that this output matches what you see on the 
+  [build server](http://procbuild.scipy.org).
 
 #### Create a paper PR
 
@@ -283,6 +300,23 @@ submission procedure.
 - Make your changes to the build system.
 - Do **not** commit any changes from your paper PR to this new branch.
 - Make a separate PR against the `dev` branch, it will be reviewed separately. 
+
+#### Push to your PR 
+
+When you push to your repositories branch it automatically updates the PR. This
+triggers a new build on the provided [build server](http://procbuild.scipy.org).
+
+#### Check your paper's build
+
+We encourage reviewers to review the pdfs built on our 
+[build server](http://procbuild.scipy.org). 
+
+You should regularly check to see if the papers that you build locally match the
+paper that you see on the server. 
+
+If it is not the same please immediately contact us with a GitHub issue
+describing the discrepancy. Please include screenshots and an explanation of the
+differences. For best results, please [@-mention the Proceedings Co-Chairs](#contacting-the-proceedings-co-chairs).
 
 ## Instructions for Reviewers
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ git clone https://github.com/mpacer/scipy_proceedings
     - If you submit multiple papers, you will need a new branch for each.
 4. Set up your environment.
 5. Write your paper, commit changes, and build your paper.
+    - If you want to alter the build system, create a separate PR against `dev`.
 6. Repeat step 6, while also responding to reviewer feedback.
 
 #### Getting a local copy of the scipy_proceedings repo 
@@ -158,6 +159,17 @@ git push --set-upstream origin <your_branch_name>
 - Once you are ready to submit your paper, file a pull request on GitHub.
   **Please ensure that you file against the correct branch**
 - Create a pull-request against our `2018` branch.
+- Do not modify any files outside of your paper directory. Create a separate PR for any changes to the build system.
+
+#### Creating build system PRs
+
+If you want to change the way the build system works, we use a separate
+submission procedure.
+
+- Create a new branch against `dev`.
+- Make your changes to the build system.
+- Do **not** commit any changes from your paper PR to this new branch.
+- Make a separate PR against the `dev` branch, it will be reviewed separately. 
 
 
 ### Reviewer Workflow

--- a/README.md
+++ b/README.md
@@ -295,4 +295,5 @@ Reviewers: You should be able to pull a built PDF for review from there.
 
 ## For organizers
 
-To build the whole proceedings, see the Makefile in the publisher directory.
+To information about how to manage the whole proceedings, please see
+`publisher/README.md` and `publisher/Makefile`.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # SciPy Proceedings
 
 This is the repository for submitting to and managing the Proceedings for the
-Annual Conference.
+Annual Scientific Computing with Python Conference.
 
 This repository is a home for authors, reviewers and editors to collaboratively
 create the proceedings for the conference.
+
+You can find more information about the [proceedings' organising principles](#organising-principles-openness) below.
 
 **All** communication between authors and reviewers should be civil and 
 respectful. There are no exceptions to this rule. Please see the 
 [SciPy2018 Code of Conduct](https://scipy2018.scipy.org/ehome/299527/648147/)
 for more info.
 
-If you are an *Author*, please see [Instructions-for-Authors](#Instructions-for-Authors).
+You can find the [schedule for 2018](#timeline-for-2018) below.
 
-If you are a *Reviewer*, please see [Instructions-for-Reviewers](#Instructions-for-Reviewers).
+Please use @-mentions in issues and pull requests(PRs) to [contact the proceedings Co-Chairs](#contacting-the-proceedings-co-chairs).
+
+If you are an *Author*, please see [Instructions for Authors](#instructions-for-authors).
+
+If you are a *Reviewer*, please see [Instructions for Reviewers](#instructions-for-reviewers). 
+
+If you are an *Editor*, please see [Instructions for Editors](#instructions-for-editors).
+
+If you are a *Publisher*, please see [Instructions for Publishers](#instructions-for-publishers).
 
 ## Organising Principles: Openness
 
@@ -22,30 +32,29 @@ Overall, the SciPy proceedings are organised to be a fully open proceedings.
 We aim to combine the best aspects of open source development, open peer review,
 and open access publication.
 
-
 ### Built by and for Open Source Communities on Open Source Tech 
 
-The technologies used for running the conference are themselves developed in the open and built on open source tools.
+The technologies used for running the conference are themselves developed in the
+open and built on open source tools.
 
-Open Development:
-    - with many people contributing code over more than a decade
-        - many contributors start as authors submitting to the proceedings 
-        - provides a natural pathway for new members to join the proceedings   
-          committee
-    - technologies are managed via public, open source GitHub repositories:
-        - build system: https://github.com/scipy-conference/scipy_proceedings
-        - server: https://github.com/scipy-conference/procbuild
+Open Development:  
+- with many people contributing code over more than a decade  
+    - many contributors start as authors submitting to the proceedings   
+    - provides a natural pathway for new members to join the proceedings committee  
+- technologies are managed via public, open source GitHub repositories:  
+    - build system: https://github.com/scipy-conference/scipy_proceedings  
+    - server: https://github.com/scipy-conference/procbuild  
 
-The systems for running the conference are built on top of open source tools:
-    - build system:
-        - LaTeX
-        - ReStructured Text (reST)
-        - Python: docutils, lxml, pygments, pytest
-    - server:
-        - Flask & waitress
-        - pyzmq
-        - Docker
-        - Python: asyncio 
+The systems for running the conference are built on top of open source tools:  
+- build system:  
+    - LaTeX  
+    - ReStructured Text (reST)  
+    - Python: docutils, lxml, pygments, pytest  
+- server:  
+    - Flask & waitress  
+    - pyzmq  
+    - Docker  
+    - Python: asyncio   
 
 ### Open Peer Review meets Open Source Code Review
 
@@ -58,27 +67,20 @@ identifiable individuals.
 - Reviews are collaborative, aiming to improve the publication quality. This is 
   possible because the content was already vetted by the program committee.
 
-- Conversations occur in the open, allowing for transparency in this open review
-  process. This holds authors and reviewers accountable and encourages civil
-  communication practices.
+- Conversations occur attached to people's real GitHub usernames and are open to
+  the public. 
+    - This allows for a transparent open review process. 
+    - This holds authors and reviewers accountable and encourages civil communication practices.
 
 ### Open Access for an Open Community
 
-The papers are published as true open access articles. The community is involved
-in the entire process for creating the proceedings, which ensures relevance to
-the community that created them.
+The papers are published as true Open Access (OA) articles with Creative Commons
+Attribution (CC By) license. 
 
-- Papers are submitted by authors who will be presenting talks and posters at the 
-  annual SciPy conference. Because we know the content is relevant to the SciPy 
-  community, review can focus on improving papers, not vetting them.
-
-- Reviewers are invited by the editors, but community members may volunteer to
-  review papers that interest them.
- 
-- There are no author processing charges barring authors from submitting papers.
+- There are no article processing charges barring authors from submitting papers.
     - Reviewers and co-chairs volunteer their time.
     - Services with free tiers (like GitHub and Heroku) allow distributing the 
-      technologies with minimal cost.
+      underlying technologies with minimal cost.
 
 - Papers are openly available at http://conference.scipy.org/proceedings/, with
   no pay walls barring consumption or author processing charges. 
@@ -86,6 +88,28 @@ the community that created them.
 - From 2017 onward, papers have DOIs (making them easily citable) and are also 
   openly available from those DOIs.
 
+The community is involved in the entire process for creating the proceedings,
+which ensures relevance to the community that created them.
+
+- Papers are submitted by authors who will be presenting talks and posters at the 
+  annual SciPy conference. Because we know the content is relevant to the SciPy 
+  community, review can focus on improving papers, not vetting them.
+
+- Reviewers are invited by the editors, but community members may volunteer to
+  review papers that interest them. The only barrier to participation is having
+  a GitHub account.
+ 
+
+## Contacting the Proceedings Co-Chairs
+
+The most effective way to contact the Proceedings Co-Chairs for issues related to this GitHub repository is to use GitHub's issues and "@"-mentioning the Co-Chairs.
+
+In 2018, the Proceedings Co-Chairs are 
+- M Pacer (@mpacer)
+- David Lippa (@dalippa)
+- Dillon Niederhut (@deniederhut)
+- Fatih Akici (@FatihAkici)
+    
 ## Timeline for 2018
 
 In addition to the following list, we break up the deadlines in the respective documents for authors and reviewers.
@@ -278,7 +302,7 @@ complete an initial review and start that conversation by the *Initial Complete 
 Deadline*.
 
 We ask that by the *Final Recommendation Deadline* you have a recommendation to
-either accept or reject the paper at that point and time. 
+either **accept** or **reject** the paper at that point and time. 
 
 **Note**:   
 You many recommend changes after the *Final Recommendation Deadline*. If there
@@ -304,29 +328,16 @@ change in question, then that change should be requested and made before the
   modifying their paper.  
 - This begins an iterative review process where authors and reviewers can discuss the
   evolving submission.
-- As you review the paper, it will help to apply **labels** to the PR to flag the 
-  current state of the review process. 
-     - The **labels** in question are:
-        - **needs-more-review** if the paper needs further review, 
-        - **pending-comment** if the paper is waiting on an authors' response, or 
-        - **unready** if the paper is not ready for the proceedings.
 - By the *Final Recommendation Deadline*, we ask that you give two things
     1. A comprehensive review of the paper as it stands. This will act as the final 
        review.  
     2. A final recommendation to include the paper in the proceedings or not.
-    - When you make the Final Recommendation, please (@)mention the editor(s) assigned 
-      to the paper. For 2018, this will be some of:
-        - M Pacer (@mpacer)
-        - David Lippa (@dalippa)
-        - Dillon Niederhut (@deniederhut)
-        - Fatih Akici (@FatihAkici)
-- Editors should come to a final 'ready', 'unready' decision before the **Final Editorial Decisions for Proceedings Contents** deadline.
-
+        - When you make the Final Recommendation, please [contact the proceedings Co-Chairs](#contacting-the-proceedings-co-chairs) in the PR in question.
+    
 ## Review Criteria
 
-A small subcommittee of the SciPy 2017 organizing committee has created [this
-set of suggested review
-criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/review_criteria.md)
+A small subcommittee of the SciPy 2017 organizing committee has created 
+[this set of suggested review criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/review_criteria.md)
 to help guide authors and reviewers alike. Suggestions and amendments to these
 review criteria are enthusiastically welcomed via discussion or pull request.
 
@@ -363,11 +374,26 @@ su -c `dnf install python-docutils texlive-collection-basic texlive-collection-f
 
 There will be a server online building open pull requests at http://procbuild.scipy.org. 
 
-Authors, you should check to ensure that your local builds match the papers built on this site. Please create an issue if they do not match.
+Authors: you should check to ensure that your local builds match the papers
+built on this site. Please create an issue if they do not match.
 
 Reviewers: You should be able to pull a built PDF for review from there.
 
-## For organizers
+## For organisers
+
+### Instructions for Publishers
 
 To information about how to manage the whole proceedings, please see
 `publisher/README.md` and `publisher/Makefile`.
+
+### Instructions for Editors
+
+As reviewers review papers, editors should apply **labels** to the PR to flag the 
+current state of the review process. 
+  - The **labels** in question are:
+    - **needs-more-review** if the paper needs further review, 
+    - **pending-comment** if the paper is waiting on an authors' response, or 
+    - **unready** if the paper is not ready for the proceedings.
+
+Editors should come to a final 'ready', 'unready' decision before the **Final Editorial Decisions for Proceedings Contents** deadline.
+

--- a/README.md
+++ b/README.md
@@ -1,44 +1,88 @@
 # SciPy Proceedings
 
-This is the repository for submitting to and managing the Proceedings for the Annual Conference.
+This is the repository for submitting to and managing the Proceedings for the
+Annual Conference.
+
+This repository is a home for authors, reviewers and editors to collaboratively
+create the proceedings for the conference.
+
+**All** communication between authors and reviewers should be civil. There are
+no exceptions to this rule.
 
 If you are an *Author*, please see [Instructions-for-Authors](#Instructions-for-Authors).
 
 If you are a *Reviewer*, please see [Instructions-for-Reviewers](#Instructions-for-Reviewers).
 
-## Organising Principles
+## Organising Principles: Openness
 
-Overall, we aim to combine the best principles of open source development and
-open academic publication processes.
+Overall, the SciPy proceedings are organised to be a fully open proceedings.
 
-**All** communication between authors and reviewers should be civil. There are
-no exceptions to this rule.
+We aim to combine the best aspects of open source development, open peer review,
+and open access publication.
 
-Authors submit papers through PRs, and reviewers review the papers through
-comments on PRs.
 
-Authors and reviewers are encouraged to work collaboratively to improve submissions
-throughout the review process, much like open source code-review.
+### Built by and for Open Source Communities on Open Source Tech 
 
-The purpose of collaborative review is primarily to improve the publication
-quality, not merely to vet and validate the content of the paper.
+The technologies used for running the conference are themselves developed in the open and built on open source tools.
 
-Conversations occur in the open, allowing for transparency in this open review
-process. This holds authors and reviewers accountable and encourages civil
-communication practices.
+Open Development:
+    - with many people contributing code over more than a decade
+        - many contributors start as authors submitting to the proceedings 
+        - provides a natural pathway for new members to join the proceedings   
+          committee
+    - technologies are managed via public, open source GitHub repositories:
+        - build system: https://github.com/scipy-conference/scipy_proceedings
+        - server: https://github.com/scipy-conference/procbuild
 
-Reviewers are invited by the editors, but community members may volunteer to
-review papers that interest them.
+The systems for running the conference are built on top of open source tools:
+    - build system:
+        - LaTeX
+        - ReStructured Text (reST)
+        - Python: docutils, lxml, pygments, pytest
+    - server:
+        - Flask & waitress
+        - pyzmq
+        - Docker
+        - Python: asyncio 
 
-All the resulting papers have DOIs (making them easily citable) and are openly
-available.
+### Open Peer Review meets Open Source Code Review
 
-The build tools are built on open source tools (LaTeX, docutils, Python, ReST).
+The entire submission and review procedure occurs through public PRs attached to
+identifiable individuals.
 
-The build tools have been developed by a variety of individuals and are managed
-via public, open source repositories (https://github.com/scipy-conference/scipy_proceedings and
-https://github.com/scipy-conference/procbuild), allowing anyone who wishes to
-adopt or extend these tools to do so easily.
+- Authors and reviewers are encouraged to work collaboratively to improve
+  submissions throughout the review process, much like open source code-review.
+
+- Reviews are collaborative, aiming to improve the publication quality. This is 
+  possible because the content was already vetted by the program committee.
+
+- Conversations occur in the open, allowing for transparency in this open review
+  process. This holds authors and reviewers accountable and encourages civil
+  communication practices.
+
+### Open Access for an Open Community
+
+The papers are published as true open access articles. The community is involved
+in the entire process for creating the proceedings, which ensures relevance to
+the community that created them.
+
+- Papers are submitted by authors who will be presenting talks and posters at the 
+  annual SciPy conference. Because we know the content is relevant to the SciPy 
+  community, review can focus on improving papers, not vetting them.
+
+- Reviewers are invited by the editors, but community members may volunteer to
+  review papers that interest them.
+ 
+- There are no author processing charges barring authors from submitting papers.
+    - Reviewers and co-chairs volunteer their time.
+    - Services with free tiers (like GitHub and Heroku) allow distributing the 
+      technologies with minimal cost.
+
+- Papers are openly available at http://conference.scipy.org/proceedings/, with
+  no pay walls barring consumption or author processing charges. 
+  
+- From 2017 onward, papers have DOIs (making them easily citable) and are also 
+  openly available from those DOIs.
 
 ## Timeline for 2018
 

--- a/README.md
+++ b/README.md
@@ -16,31 +16,30 @@ If you are a *Reviewer*, please see [Instructions-for-Reviewers](#Instructions-f
 
 
 
-## Schedule Summary
 
-Authors may make changes to their submisions throughout the review process.
 
-There are many different styles of review (some do paragraph comments, others
-do 'code review' style line edits) and the process is open.
 ## Instructions for Authors
 
-We encourage authors and reviewers to work together iteratively to make each 
-others papers the best they can be.
-Combine the best principles of open source development and academic publication.
+Please submit your papers by 23:59 PST of the *1st Draft for Submission* 
+Deadline.
 
-These dates are the tentative timeline for 2017:
+During the Open Review Period authors should work with their reviewers to refine
+and improve their submission.
 
-- May 4th - Authors invited to submit full papers
-- June 6th - Initial submissions due
-- June 7th - Reviewers assigned
-- June 21st - Reviews due
-- June 21st -July 7th: Authors revise papers based on reviews
-- July 7th - Acceptance/rejection of papers
-- July 8th - Papers must be camera-ready
-- July 10-16th - Conference
-- July 20th - Publication
+Authors should respond to all the reviewers' comments. 
 
-## General Guidelines
+**All** communication between authors and reviewers should be civil at all times. 
+
+Authors should default to modifying their papers in response to reviewers'
+comments. In some cases, authors may not agree with the reviewers comments. 
+
+If the authors do not agree with the comments or do not wish to implement the
+suggested changes, the authors and reviewers should attempt to discuss this in
+the PR's comment sections. It is important to remember in this case that we expect **all** communication between authors and reviewers to be civil.
+
+In the event that the authors and reviewers find
+themselves unable to resolve a disagreement about a recommendation, they should
+alert a Proceedings Co-Chair to this situation.
 
 ### General Information and Guidelines for Authors:
 
@@ -170,6 +169,32 @@ submission procedure.
 - Make your changes to the build system.
 - Do **not** commit any changes from your paper PR to this new branch.
 - Make a separate PR against the `dev` branch, it will be reviewed separately. 
+
+## Instructions for Reviewers
+
+You will be reviewing authors' pull requests. While authors should have a proper
+draft of their paper ready for you by *1st Draft Submission* deadline. 
+
+We ask that you read [this set of suggested review criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/review_criteria.md) before beginning any reviews.
+
+**All** communication between authors and reviewers should be civil at all times. 
+
+The goal of our review process is to improve the paper that the authors are
+working on. Our aim is to have you and the author collaborate on making their
+better by using an iterative process.  
+
+While our basic approach is to have you and the author iterate, we ask you to
+complete an initial review and start that conversation by the *Initial Complete Review
+Deadline*.
+
+We ask that by the *Final Recommendation Deadline* you have a recommendation to
+either accept or reject the paper at that point and time. 
+
+**Note**: You may still recommend changes after the *Final Recommendation 
+Deadline*, but these should be seen as recommendations. There should be no large 
+outstanding issues remaining. As a heuristic, if you think the paper should not 
+be in the proceedings unless the authors make the change in question, then that 
+change should be made before the *Final Recommendation Deadline*.
 
 
 ### Reviewer Workflow

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Annual Conference.
 This repository is a home for authors, reviewers and editors to collaboratively
 create the proceedings for the conference.
 
-**All** communication between authors and reviewers should be civil. There are
-no exceptions to this rule.
+**All** communication between authors and reviewers should be civil and 
+respectful. There are no exceptions to this rule. Please see the 
+[SciPy2018 Code of Conduct](https://scipy2018.scipy.org/ehome/299527/648147/)
+for more info.
 
 If you are an *Author*, please see [Instructions-for-Authors](#Instructions-for-Authors).
 
@@ -105,20 +107,23 @@ Deadline.
 During the Open Review Period authors should work with their reviewers to refine
 and improve their submission.
 
+Proceedings Co-Chairs have final say in determining whether a paper is to be
+accepted to the proceedings.
+
 Authors should respond to all the reviewers' comments. 
 
-**All** communication between authors and reviewers should be civil at all times. 
-
 Authors should default to modifying their papers in response to reviewers'
-comments. In some cases, authors may not agree with the reviewers comments. 
+comments. 
 
-If the authors do not agree with the comments or do not wish to implement the
-suggested changes, the authors and reviewers should attempt to discuss this in
-the PR's comment sections. It is important to remember in this case that we expect **all** communication between authors and reviewers to be civil.
+Authors may not agree with the reviewers comments or may not wish to implement
+the suggested changes. In those cases, the authors and reviewers should
+attempt to discuss this in the PR's comment sections. It is important to
+remember in these cases that we expect **all** communication between authors and
+reviewers to be civil and respectful.
 
-In the event that the authors and reviewers find
-themselves unable to resolve a disagreement about a recommendation, they should
-alert a Proceedings Co-Chair to this situation.
+In the event that authors and reviewers are deadlocked, they should alert the
+Proceedings Co-Chairs to this situation. As always, the Proceedings Co-Chairs
+have final say in whether to accept or reject a paper.
 
 ### Author Deadlines
 
@@ -262,7 +267,7 @@ draft of their paper ready for you by *1st Draft Submission* deadline.
 
 We ask that you read [this set of suggested review criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/review_criteria.md) before beginning any reviews.
 
-**All** communication between authors and reviewers should be civil at all times. 
+**All** communication between authors and reviewers should be civil and respectful at all times. 
 
 The goal of our review process is to improve the paper that the authors are
 working on. Our aim is to have you and the author collaborate on making their
@@ -275,11 +280,13 @@ Deadline*.
 We ask that by the *Final Recommendation Deadline* you have a recommendation to
 either accept or reject the paper at that point and time. 
 
-**Note**: You may still recommend changes after the *Final Recommendation 
-Deadline*, but these should be seen as recommendations. There should be no large 
-outstanding issues remaining. As a heuristic, if you think the paper should not 
-be in the proceedings unless the authors make the change in question, then that 
-change should be made before the *Final Recommendation Deadline*.
+**Note**:   
+You many recommend changes after the *Final Recommendation Deadline*. If there
+are any major changes after the *Final Recommendation Deadline* you should
+immediately contact the Proceedings Committee Co-Chairs. As a heuristic, if you
+think the paper should not be in the proceedings unless the authors make the
+change in question, then that change should be requested and made before the
+*Final Recommendation Deadline*.
 
 ### Reviewer Deadlines
 

--- a/README.md
+++ b/README.md
@@ -7,34 +7,14 @@ If you are an *Author*, please see [Instructions-for-Authors](#Instructions-for-
 If you are a *Reviewer*, please see [Instructions-for-Reviewers](#Instructions-for-Reviewers).
 
 
-Papers are formatted using reStructuredText and the compiled version should be
-no longer than 8 pages, including figures.  Here are the steps to produce a
-paper:
 
-- Fork the
-  [scipy_proceedings](https://github.com/scipy-conference/scipy_proceedings)
-  repository on GitHub.
 
-- Check out the 2017 branch (``git checkout 2017``).
 
-- Create a new environment (using your choice of environment manager, e.g., ``pyenv`` or ``conda``).
 
-- Install/update the required python libraries (``pip install -U -r requirements.txt``).
 
-- An example paper is provided in ``papers/00_vanderwalt``.  Create a new
-  directory ``papers/firstname_surname``, copy the example paper into it, and
-  modify to your liking.
 
-- Run ``./make_paper.sh papers/firstname_surname`` to compile your paper to
-  PDF (requires LaTeX, docutils, Python--see below).  The output appears in
-  ``output/firstname_surname/paper.pdf``.
 
-- Once you are ready to submit your paper, file a pull request on GitHub.
-  **Please ensure that you file against the correct branch**--your branch
-  should be named 2017, and the pull-request should be against our 2017
-  branch.
 
-- Please do not modify any files outside of your paper directory.
 
 ## Schedule Summary
 
@@ -81,6 +61,104 @@ These dates are the tentative timeline for 2017:
 - Do not modify any files outside of your paper directory. 
 - The compiled version of the paper (PDF) should be at most 8 pages,
   including figures and references.
+
+### Author Workflow
+
+Below we outline the steps to submit a paper.
+
+Before you begin, you should have a GitHub account. If we refer to `<username>`
+in code examples, you should replace that with your GitHub username. 
+
+More generally, angle brackets with a value inside are meant to be replaced with
+the value that applies to you. 
+
+For example, if your GitHub username was `mpacer`, you would transform 
+
+```
+git clone https://github.com/<username>/scipy_proceedings
+```
+
+into: 
+
+```
+git clone https://github.com/mpacer/scipy_proceedings
+```
+
+1. Get a local copy of the `scipy_proceedings` repo.
+2. Update your local copy of the `scipy_proceedings` repo.
+3. Create a new branch for your paper based off the latest `2018` branch.
+    - If you submit multiple papers, you will need a new branch for each.
+4. Set up your environment.
+5. Write your paper, commit changes, and build your paper.
+6. Repeat step 6, while also responding to reviewer feedback.
+
+#### Getting a local copy of the scipy_proceedings repo 
+
+- If you do not have a GitHub account, create one. 
+- Fork the
+  [scipy_proceedings](https://github.com/scipy-conference/scipy_proceedings)
+  repository on GitHub.
+- Clone the repo locally 
+    - `git clone https://github.com/<username>/scipy_proceedings`
+- Add the `scipy-conference` repository as your `upstream` remote
+    - `git remote add upstream https://github.com/scipy-conference/scipy_proceedings`
+
+If you run `git remote -v  ` you should see something like the following: 
+```
+origin	https://github.com/<username>/scipy_proceedings.git (fetch)
+origin	https://github.com/<username>/scipy_proceedings.git (push)
+upstream	https://github.com/scipy-conference/scipy_proceedings.git (fetch)
+upstream	https://github.com/scipy-conference/scipy_proceedings.git (push)
+```
+
+#### Getting the latest `2018` branch
+
+- Fetch the latest version of the `scipy_proceedings` repo
+    - `git fetch upstream`
+- Check out the upstream `2018` branch 
+    - `git checkout -b 2018 --track upstream/2018`
+
+#### Creating a new branch based off of `2018`
+
+If you are submitting only one paper, you can use the `2018` directly.
+
+Otherwise, you will need to create a new branch based on `2018` and set its
+upstream to origin.
+
+```
+git checkout 2018
+git checkout -b <your_branch_name> 
+git push --set-upstream origin <your_branch_name>
+```
+
+#### Setting up your environment
+
+- Create a new environment (using your choice of environment manager, e.g., `pyenv` or `conda`).
+- Install/update the required python libraries (`pip install -U -r requirements.txt`).
+- Install LaTeX and any other non-python dependencies 
+- Create a new directory `papers/<your_directory_name>`
+    - if you are submitting one paper, we recommend you use `<firstname_surname>`
+    - if you are submitting more than one paper, you will need to use a different 
+      directory name for each paper
+
+#### Write your paper
+
+- Copy an example paper into your directory.
+    - You must have only one reST file in the top level of `<your_directory_name>`.
+- As you make changes to your paper, commit those changes in discrete chunks. 
+- Do not modify any files outside of your paper directory.
+
+#### Build your paper
+
+- Run `./make_paper.sh papers/firstname_surname` to make a PDF of your paper 
+- Check the output in `output/<your_directory_name>/paper.pdf`.
+
+#### Create a paper PR
+
+- Once you are ready to submit your paper, file a pull request on GitHub.
+  **Please ensure that you file against the correct branch**
+- Create a pull-request against our `2018` branch.
+
 
 ### Reviewer Workflow
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,11 @@
 # SciPy Proceedings
 
-## Instructions for Reviewers
+This is the repository for submitting to and managing the Proceedings for the Annual Conference.
 
-- Click on the Pull Requests Tab and browse to find the papers assigned to you
-- After reading the paper, you can start the review conversation by simply commenting
-  on the paper, taking into consideration
-  [this set of suggested review criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/review_criteria.md).
-- Please submit a comprehensive review by **June 21st.**
-- Authors will then respond to the comments and/or modify the paper to address the comments. 
-- This will begin an iterative review process where authors and reviewers can discuss the
-  evolving submission.
-- Reviewers may also apply one of the labels 'needs-more-review', 'pending-comment', or 
-  'unready' to flag the current state of the review process.
-- Only once a reviewer is satisfied that the review process is complete and the submission should
-  be accepted to the proceedings, should they affix the 'ready' label. 
-- Reviewers should come to a final 'ready', 'unready' decision before **July 7th** at 18:00 PST.
+If you are an *Author*, please see [Instructions-for-Authors](#Instructions-for-Authors).
 
-## Instructions for Authors
+If you are a *Reviewer*, please see [Instructions-for-Reviewers](#Instructions-for-Reviewers).
 
-Submissions must be received by **June 6th** at 23:59 PST, but modifications are
-allowed during the open review period which ends July 8th at 18:00 PST.  Submissions are
-considered received once a Pull Request has been opened following the procedure
-outlines below.
 
 Papers are formatted using reStructuredText and the compiled version should be
 no longer than 8 pages, including figures.  Here are the steps to produce a
@@ -58,6 +42,7 @@ Authors may make changes to their submisions throughout the review process.
 
 There are many different styles of review (some do paragraph comments, others
 do 'code review' style line edits) and the process is open.
+## Instructions for Authors
 
 We encourage authors and reviewers to work together iteratively to make each 
 others papers the best they can be.
@@ -77,6 +62,15 @@ These dates are the tentative timeline for 2017:
 
 ## General Guidelines
 
+### General Information and Guidelines for Authors:
+
+- Papers are formatted using reStructuredText.
+- Example papers are provided in `papers/00_bibderwalt` and `papers/00_vanderwalt`.
+    - These papers provide examples of how to:
+        - Label figures, equations and tables
+        - Use math markup
+        - Include code snippets
+    - `00_bibderwalt` also shows how to use a bib file for citations
 - All figures and tables should have captions.
 - Figures and tables should be positioned inline, close to their explanatory text.
 - License conditions on images and figures must be respected (Creative Commons,
@@ -84,6 +78,37 @@ These dates are the tentative timeline for 2017:
 - Code snippets should be formatted to fit inside a single column without
   overflow.
 - Avoid custom LaTeX markup where possible.
+- Do not modify any files outside of your paper directory. 
+- The compiled version of the paper (PDF) should be at most 8 pages,
+  including figures and references.
+
+### Reviewer Workflow
+
+- Read [this set of suggested review criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/review_criteria.md)
+- Click on the Pull Requests Tab and find the papers assigned to you
+- After reading the paper, you can start the review conversation however you prefer
+    - You can use line comments (on the paper itself) or high-level comments.
+- Authors will respond to your comments, possibly via their own comments or by 
+  modifying their paper.  
+- This begins an iterative review process where authors and reviewers can discuss the
+  evolving submission.
+- As you review the paper, it will help to apply **labels** to the PR to flag the 
+  current state of the review process. 
+     - The **labels** in question are:
+        - **needs-more-review** if the paper needs further review, 
+        - **pending-comment** if the paper is waiting on an authors' response, or 
+        - **unready** if the paper is not ready for the proceedings.
+- By the *Final Recommendation Deadline*, we ask that you give two things
+    1. A comprehensive review of the paper as it stands. This will act as the final 
+       review.  
+    2. A final recommendation to include the paper in the proceedings or not.
+    - When you make the Final Recommendation, please (@)mention the editor(s) assigned 
+      to the paper. For 2018, this will be some of:
+        - M Pacer (@mpacer)
+        - David Lippa (@dalippa)
+        - Dillon Niederhut (@deniederhut)
+        - Fatih Akici (@FatihAkici)
+- Editors should come to a final 'ready', 'unready' decision before the **Final Editorial Decisions for Proceedings Contents** deadline.
 
 ## Review Criteria
 
@@ -93,14 +118,6 @@ criteria](https://github.com/scipy-conference/scipy_proceedings/blob/master/revi
 to help guide authors and reviewers alike. Suggestions and amendments to these
 review criteria are enthusiastically welcomed via discussion or pull request.
 
-## Other markup
-
-Please refer to the example paper in ``papers/00_vanderwalt`` for
-examples of how to:
-
- - Label figures, equations and tables
- - Use math markup
- - Include code snippets
 
 ## Requirements
 


### PR DESCRIPTION
This PR updates the README to have new dates for 2018 as well as restructures them to reflect conversations had during the 2018 proceedings committee meetings.

Key points:
- updates dates with new dates
- updates server link

There are also a number of major changes:
- This removes dates from the plaintext descriptions, making it easier to find and modify the dates in the future. 
    - plain text now refers to the named event that occurs on the date (not the date itself)
- This creates a top level schedule and Author/Reviewer specific list of Deadlines
- Author and Reviewer sections are now linked to and better encapsulated
    - this should make it possible to isolate these sections in separate files, 
    - this is part of a larger process to make the top-level README more useful in general while ensuring authors and reviewers have all the details they need.
- This adds *much* greater detail for new Authors on how to make a submission
- This adds a new section describing how to make PRs that change the build system
- This adds a new Organising principles section describing the ways in which Openness is manifested in the decisions made to organise the conference.
    - This is also part of the larger proecess to make the top-level README more generally useful
- This now links to the publisher README for more information.

@dalippa  I imagine you in particular would care about this PR.