### PR TITLE
Update mailings

### DIFF
--- a/publisher/mail/_mailer.py
+++ b/publisher/mail/_mailer.py
@@ -187,6 +187,8 @@ class Mailer:
     def recipient_greeting(names):
         if len(names) == 1:
             name_string = names[0]
+        elif len(names) == 2:
+            name_string = " and ".join(names)
         else:
             name_string = ', '.join(names[:-1]) + ', and ' + names[-1]
         return name_string
@@ -333,6 +335,8 @@ class Mailer:
         
         """
         data = {} if data is None else data
+        self.temp_data = data
+        
         recipients_list = self.recipients_list if recipients_list is None else recipients_list
         self.prep_data({**data, 'recipients': ", ".join(recipients_list)})
 
@@ -342,6 +346,7 @@ class Mailer:
             self.display_message(self.send_list(recipients_list), message)
         else:
             self.send_mail(self.send_list(recipients_list), message)
+        self.temp_data = {}
 
     def send_list(self, recipients_list):
         return list(set(recipients_list+self.cc_list))
@@ -355,8 +360,9 @@ class Mailer:
     def send_mail(self, recipients_list, message):
         print('-> %s' % recipients_list)
         with self.session() as session:
-            import ipdb; ipdb.set_trace()
-            session.sendmail(self.sender['name'], recipients_list, message)
+            # if we ever change the assumption that it's only a plaintext email 
+            # we will need to revisit this encoding as 'utf-8'
+            session.sendmail(self.sender['name'], recipients_list, message.encode('utf-8'))
 
     @contextmanager
     def session(self):

--- a/publisher/mail/_mailer.py
+++ b/publisher/mail/_mailer.py
@@ -217,6 +217,18 @@ class Mailer:
         eml_strs = ('"{name}" <{email}>'.format(**p) for p in people_gen if are_str(p))
         return ", ".join(eml_strs)
 
+    @classmethod
+    def editor_email_string(cls, data=None):
+        if data is None:
+            data = cfg2dict(proc_conf).get('proceedings', {})
+        return cls.fancy_emails(data, name_key='editor', email_key='editor_email')
+
+    @classmethod
+    def create_committee(cls, data=None):
+        if data is None:
+            data = cfg2dict(proc_conf)
+        proc = data.get('proceedings', {})
+        return cls.fancy_prep(proc, name_key="editor", email_key='editor_email')
 
     @property
     def recipients(self):
@@ -258,8 +270,8 @@ class Mailer:
     
     @property
     def common_data(self):
-        return {'editor_email_string':  editor_email_string(),
-                'committee': create_committee()}
+        return {'editor_email_string': self.editor_email_string(),
+                'committee': self.create_committee()}
     
     @property
     def custom_data(self):
@@ -276,7 +288,7 @@ class Mailer:
         """
         data = {} if data is None else data
         recipients = self.recipients if recipients is None else recipients
-        self.prep_data({**data, 'recipients':recipients})
+        self.prep_data({**data, 'recipients': recipients})
 
         message = _from_template(self.template, self.template_data)
         
@@ -284,7 +296,6 @@ class Mailer:
             self.display_message(recipients, message)
         else:
             self.send_mail(recipients, message)
-
 
     def display_message(self, recipients, message):
         print('Dry run -> not sending mail to %s' % recipients)

--- a/publisher/mail/_mailer.py
+++ b/publisher/mail/_mailer.py
@@ -6,7 +6,8 @@ from email.mime.text import MIMEText
 
 import sys
 sys.path.insert(0, '..')
-from conf import work_dir
+
+from conf import proc_conf
 from options import cfg2dict
 from build_template import _from_template
 
@@ -14,11 +15,13 @@ from build_template import _from_template
 args = None
 password = None
 
+
 def author_greeting(names):
     if len(names) == 1:
         return names[0]
     else:
         return ', '.join(names[:-1]) + ', and ' + names[-1]
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Invite reviewers.")
@@ -49,6 +52,40 @@ def email_addr_from(name_email):
     return '"%s" <%s>' % (name_email['name'], name_email['email'])
 
 
+def create_committee(data=None):
+    if data is None:
+        data = cfg2dict(proc_conf)
+    proc = data.get('proceedings', {})
+    editors = proc.get('editor', [])
+    # editor_email = [x.strip() for x in proc.get('editor_email', '').split(',')]
+    editor_email = proc.get('editor_email')
+    assert len(editors) == len(editor_email)
+    return [{"name": name, 
+             "email": email} 
+            for name, email 
+            in zip(editors, editor_email)]
+
+def editor_email_string(data=None):
+    if data is None:
+        data = cfg2dict(proc_conf)
+    editor_email_list = data.get('proceedings', {}).get('editor_email',[])
+    return ', '.join(editor_email_list)
+
+def create_message(recipient, template, template_data):
+    template_data['email'] = recipient
+    template_path = resolve_template(template, '../mail/templates/')
+    return _from_template(template_path, template_data)
+
+
+def resolve_template(template_name, base_dir):
+    template_path = os.path.join(base_dir, template_name)
+    # This needs to be add '.tmpl' because that's what _from_template expects
+    if not os.path.exists(template_path +'.tmpl'):
+        raise ValueError('There is no template file at {}.'.format(template_path+'.tmpl'))
+    else:
+        return os.path.abspath(template_path)
+
+
 def send_template(sender, recipient, template, template_data,
                   smtp_server='smtp.gmail.com', smtp_port=587):
     if args.dry_run:
@@ -56,15 +93,13 @@ def send_template(sender, recipient, template, template_data,
     else:
         get_password(sender['login'])
         print('-> %s' % recipient)
-
-    template_data['email'] = recipient
-    message = _from_template('../mail/templates/' + template, template_data)
+    
+    message = create_message(recipient, template, template_data)
 
     if args.dry_run:
         print("=" * 80)
         print(message)
         print("=" * 80)
-
         return
 
     session = smtplib.SMTP(smtp_server, smtp_port)

--- a/publisher/mail/email.json
+++ b/publisher/mail/email.json
@@ -1,22 +1,24 @@
 {
-
-  "conference": "SciPy 2011",
-  "year": "2011",
+  "conference": "SciPy 2018",
+  "year": "2018",
   "due": "April 29, 2012",
-  "download": "http://jarrodmillman.com/scipy2011",
-  "editors": "Stefan van der Walt and Jarrod Millman",
+  "submission_date": "May 21st, 2018",
+  "download": "http://procbuild.scipy.org",
   "sender": {
-     "login": "jarrod.millman",
-     "name": "Jarrod Millman <jarrod.millman+scipy2011@gmail.com>",
+     "login": "mpacer",
+     "name": "M Pacer <mpacer.phd+scipyproc@gmail.com>",
      "password": "test"
    },
 
-   "submit_email": "jarrod.millman+scipy2011@gmail.com",
+   "submit_email": "mpacer.phd+scipyproc@gmail.com",
    "review_form": "https://raw.github.com/scipy/scipy_proceedings/master/reviews/review-template.rst",
-   "cced": "millman.ucb@gmail.com, sjvdwalt@gmail.com",
+   "github_url": "https://github.com/scipy-conference/scipy_proceedings",
+   "readme_url": {
+     "authors": "https://github.com/scipy-conference/scipy_proceedings#instructions-for-authors",
+     "reviewers": "https://github.com/scipy-conference/scipy_proceedings#instructions-for-reviewers"
+   },
 
-   "reviews_url": "http://jarrodmillman.com/scipy2011-reviews",
-   "built_proceedings_url": "http://jarrodmillman.com/scipy2011",
+   "built_proceedings_url": "http://procbuild.scipy.org",
 
    "reviewers": [
      {"name": "Stefan van der Walt",

--- a/publisher/mail/email.json
+++ b/publisher/mail/email.json
@@ -13,6 +13,7 @@
    "submit_email": "mpacer.phd+scipyproc@gmail.com",
    "review_form": "https://raw.github.com/scipy/scipy_proceedings/master/reviews/review-template.rst",
    "github_url": "https://github.com/scipy-conference/scipy_proceedings",
+   "reviews_url": "https://github.com/scipy-conference/scipy_proceedings/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3Apaper",
    "readme_url": {
      "authors": "https://github.com/scipy-conference/scipy_proceedings#instructions-for-authors",
      "reviewers": "https://github.com/scipy-conference/scipy_proceedings#instructions-for-reviewers"

--- a/publisher/mail/email.json
+++ b/publisher/mail/email.json
@@ -5,7 +5,7 @@
   "submission_date": "May 21st, 2018",
   "download": "http://procbuild.scipy.org",
   "sender": {
-     "login": "mpacer",
+     "login": "mpacerphd",
      "name": "M Pacer <mpacer.phd+scipyproc@gmail.com>",
      "password": "test"
    },

--- a/publisher/mail/mail_authors.py
+++ b/publisher/mail/mail_authors.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python
 
 import _mailer as mailer
+from options import cfg2dict
+from conf import proc_conf
 
 args = mailer.parse_args()
-config = mailer.load_config('email.json')
+config = cfg2dict('email.json')
+scipy_config = cfg2dict(proc_conf)
+config.update(scipy_config)
+
+template = args.template or 'author-revision.txt'
 
 for author in config['authors']:
     to = mailer.email_addr_from(author)
-    mailer.send_template(config['sender'], to, args.template, config)
+    config['committee'] =  mailer.create_committee(scipy_config)
+    config['editor_email_string'] =  mailer.editor_email_string()
+    config['recipients'] = to
+    mailer.send_template(config['sender'], to, template, config)
 
 print("Mail for %d authors." % len(config['authors']))

--- a/publisher/mail/mail_call_for_papers.py
+++ b/publisher/mail/mail_call_for_papers.py
@@ -9,14 +9,12 @@ from options import cfg2dict
 class AuthorMailer(Mailer):
     @property
     def recipients_list(self):
-        send_to = {"names": ["David Lippa", "M Pacer", "Elizabeth Seiver"], 
-                   "emails": ["dalippa@cs.brandeis.edu", "mpacer@berkeley.edu", "elizabethseiver@gmail.com"]}
-        # send_to = {"names": ["David Lippa"],
-        #            "emails": ["dalippa@cs.brandeis.edu"]}
-        return self.fancy_email_list(send_to, name_key="names", email_key="emails")
+        # send_to = {"names": ["David Lippa", "M Pacer"],
+        #            "emails": ["dalippa@gmail.com", "mpacer@berkeley.edu"]}
+        # return self.fancy_email_list(send_to, name_key="names", email_key="emails")
         
-        # send_to = self.template_data
-        # return self.fancy_emails(send_to, name_key="authors", email_key="emails")
+        send_to = self.temp_data
+        return self.fancy_email_list(send_to, name_key="authors", email_key="emails")
 
     @property
     def custom_data(self):
@@ -27,10 +25,10 @@ args = parse_args()
 template = args.template or 'call_for_papers.txt'
 
 accepts = cfg2dict('./accepted_talks_and_posters.json')
+mailer = AuthorMailer(template=template, 
+                      dry_run=args.dry_run)
+                      
 for proposal, info in accepts.items():
-    mailer = AuthorMailer(template=template, 
-                          data_sources=[info],
-                          dry_run=args.dry_run)
     
-    mailer.send_from_template()
+    mailer.send_from_template(data=info)
     import ipdb; ipdb.set_trace()

--- a/publisher/mail/mail_call_for_papers.py
+++ b/publisher/mail/mail_call_for_papers.py
@@ -8,14 +8,15 @@ from options import cfg2dict
 
 class AuthorMailer(Mailer):
     @property
-    def recipients(self):
-        # this is for testing
-        # send_to = {"names": ["M Pacer", "David Lippa"], 
-        #            "emails": ["mpacer@berkeley.edu", "dalippa@gmail.com"]}
-        # return self.fancy_emails(send_to, name_key="names", email_key="emails")
+    def recipients_list(self):
+        send_to = {"names": ["David Lippa", "M Pacer", "Elizabeth Seiver"], 
+                   "emails": ["dalippa@cs.brandeis.edu", "mpacer@berkeley.edu", "elizabethseiver@gmail.com"]}
+        # send_to = {"names": ["David Lippa"],
+        #            "emails": ["dalippa@cs.brandeis.edu"]}
+        return self.fancy_email_list(send_to, name_key="names", email_key="emails")
         
-        send_to = self.template_data
-        return self.fancy_emails(send_to, name_key="authors", email_key="emails")
+        # send_to = self.template_data
+        # return self.fancy_emails(send_to, name_key="authors", email_key="emails")
 
     @property
     def custom_data(self):
@@ -28,6 +29,8 @@ template = args.template or 'call_for_papers.txt'
 accepts = cfg2dict('./accepted_talks_and_posters.json')
 for proposal, info in accepts.items():
     mailer = AuthorMailer(template=template, 
-                          data_sources=[info])
+                          data_sources=[info],
+                          dry_run=args.dry_run)
     
     mailer.send_from_template()
+    import ipdb; ipdb.set_trace()

--- a/publisher/mail/mail_call_for_papers.py
+++ b/publisher/mail/mail_call_for_papers.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from _mailer import Mailer, parse_args
+
+from conf import toc_conf, proc_conf
+from options import cfg2dict
+
+args = parse_args()
+template = args.template or 'call_for_papers.txt'
+
+scipy_proc = cfg2dict(proc_conf)
+toc = cfg2dict(toc_conf)
+
+class AuthorMailer(Mailer):
+    @property
+    def recipients(self):
+        return ', '.join(self.template_data['author_email'])
+
+    @property
+    def custom_data(self):
+        return {'author': self.recipient_greeting(self.template_data['author'])}
+
+for paper in toc['toc']:
+
+    mailer = AuthorMailer(template=template, 
+                          data_sources=[scipy_proc, 
+                                        paper])
+                                        
+    recipients = ','.join(paper['author_email'])
+    mailer.send_from_template(recipients)
+

--- a/publisher/mail/mail_call_for_papers.py
+++ b/publisher/mail/mail_call_for_papers.py
@@ -18,7 +18,9 @@ class AuthorMailer(Mailer):
 
     @property
     def custom_data(self):
-        return {'author': self.recipient_greeting(self.template_data['authors'])}
+        return {'author': self.recipient_greeting(self.temp_data['authors']),
+                'abstract_title': self.temp_data['title']}
+
 
 
 args = parse_args()
@@ -31,4 +33,3 @@ mailer = AuthorMailer(template=template,
 for proposal, info in accepts.items():
     
     mailer.send_from_template(data=info)
-    import ipdb; ipdb.set_trace()

--- a/publisher/mail/mail_call_for_papers.py
+++ b/publisher/mail/mail_call_for_papers.py
@@ -2,30 +2,32 @@
 
 from _mailer import Mailer, parse_args
 
-from conf import toc_conf, proc_conf
 from options import cfg2dict
 
-args = parse_args()
-template = args.template or 'call_for_papers.txt'
 
-scipy_proc = cfg2dict(proc_conf)
-toc = cfg2dict(toc_conf)
 
 class AuthorMailer(Mailer):
     @property
     def recipients(self):
-        return ', '.join(self.template_data['author_email'])
+        # this is for testing
+        # send_to = {"names": ["M Pacer", "David Lippa"], 
+        #            "emails": ["mpacer@berkeley.edu", "dalippa@gmail.com"]}
+        # return self.fancy_emails(send_to, name_key="names", email_key="emails")
+        
+        send_to = self.template_data
+        return self.fancy_emails(send_to, name_key="authors", email_key="emails")
 
     @property
     def custom_data(self):
-        return {'author': self.recipient_greeting(self.template_data['author'])}
+        return {'author': self.recipient_greeting(self.template_data['authors'])}
 
-for paper in toc['toc']:
 
+args = parse_args()
+template = args.template or 'call_for_papers.txt'
+
+accepts = cfg2dict('./accepted_talks_and_posters.json')
+for proposal, info in accepts.items():
     mailer = AuthorMailer(template=template, 
-                          data_sources=[scipy_proc, 
-                                        paper])
-                                        
-    recipients = ','.join(paper['author_email'])
-    mailer.send_from_template(recipients)
-
+                          data_sources=[info])
+    
+    mailer.send_from_template()

--- a/publisher/mail/mail_dois.py
+++ b/publisher/mail/mail_dois.py
@@ -1,26 +1,24 @@
 #!/usr/bin/env python
 
-import os
-
 import _mailer as mailer
-from conf import work_dir, toc_conf, proc_conf
-import options
+from conf import toc_conf, proc_conf
+from options import cfg2dict
 
 args = mailer.parse_args()
-scipy_proc = options.cfg2dict(proc_conf)
-toc = options.cfg2dict(toc_conf)
+scipy_proc = cfg2dict(proc_conf)
+toc = cfg2dict(toc_conf)
 
 sender = scipy_proc['proceedings']['xref']['depositor_email']
 template = 'doi-notification.txt'
 template_data = scipy_proc.copy()
-template_data['proceedings']['editor_email'] = ', '.join(template_data['proceedings']['editor_email'])
 
 for paper in toc['toc']:
 
     template_data.update(paper)
     recipients = ','.join(template_data['author_email'])
     template_data['author'] = mailer.author_greeting(template_data['author'])
-    template_data['author_email'] = ', '.join(template_data['author_email'])
-    template_data['committee'] = '\n  '.join(template_data['proceedings']['editor'])
+    template_data['committee'] = mailer.create_committee()
+    template_data['editor_email_string'] =  mailer.editor_email_string()
+    template_data['recipients'] = ', '.join(template_data['author_email'])
 
     mailer.send_template(sender, recipients, template, template_data)

--- a/publisher/mail/mail_reviewers.py
+++ b/publisher/mail/mail_reviewers.py
@@ -3,9 +3,11 @@
 import _mailer as mailer
 import os
 from conf import work_dir
+from options import cfg2dict
 
 args = mailer.parse_args()
-config = mailer.load_config('email.json')
+config = cfg2dict('email.json')
+config['committee'] = mailer.create_committee()
 
 
 for reviewer_info in config['reviewers']:
@@ -17,10 +19,11 @@ for reviewer_info in config['reviewers']:
 for reviewer_info in config['reviewers']:
     reviewer_config = config.copy()
     reviewer_config.update(reviewer_info)
-    reviewer = reviewer_info['email']
+    reviewer_config['editor_email_string'] =  mailer.editor_email_string()
 
     to = mailer.email_addr_from(reviewer_info)
-    mailer.send_template(config['sender'], to + ', ' + config['cced'],
+    reviewer_config['recipients'] = to
+    mailer.send_template(config['sender'], to,
                          'reviewer-invite.txt', reviewer_config)
 
 
@@ -36,8 +39,6 @@ for paper in paper_reviewers:
     print("%s:" % paper)
     for reviewer in paper_reviewers[paper]:
         print("->", reviewer)
-    print
 
 print("Papers:", len(paper_reviewers))
 print("Reviewers:", len(config['reviewers']))
-print

--- a/publisher/mail/templates/author-revision.txt.tmpl
+++ b/publisher/mail/templates/author-revision.txt.tmpl
@@ -1,7 +1,7 @@
 From: {{sender['name'] | html}}
 Subject: [{{conference}}] reviews submitted, revisions requested
-To: {{email | html}}
-Cc: {{cced | html}}
+To: {{recipients | html}}
+Cc: {{editor_email_string | html}}
 MIME-Version: 1.0
 Content-Type: text/plain
 
@@ -31,4 +31,6 @@ is {{due}}.
 
 With best regards,
 
-{{editors}}
+{{for cochair in committee}}
+- {{cochair['name']}} <{{cochair['email']}}>
+{{endfor}}

--- a/publisher/mail/templates/call_for_papers.txt.tmpl
+++ b/publisher/mail/templates/call_for_papers.txt.tmpl
@@ -1,0 +1,46 @@
+From: {{sender['name'] | html}}
+Subject: [{{conference}}] invitation to submit to proceedings
+To: {{recipients | html}}
+Cc: {{editor_email_string | html}}
+MIME-Version: 1.0
+Content-Type: text/plain
+
+Dear {{author}},
+
+Congratulations on having your abstract accepted for this year's event -- we 
+look forward to seeing your poster or presentation! As in the past, SciPy2018 
+will release a conference proceedings prior to the start of the conference, 
+and you are invited to contribute a full-length paper (up to 8 pages) expanding 
+on your abstract.
+
+The proceedings are aimed at highlighting significant contributions to 
+scientific computing in Python, such as:
+
+- new software packages that support the Scientific Python Stack
+- domain-specific applications of Python in any field of research
+- significant improvements to existing software packages
+- hardware systems designed to support the Python stack
+- applications of scientific computing in education
+
+Papers must be submitted as pull requests by {{submission_date}}. At that
+point, the six-week open review period will begin. During this time, members
+from the program committee and the scientific Python community at large will
+provide feedback, which should be addressed through discussion on GitHub and by
+updating the pull request.
+
+When submitting a paper to the proceedings, you may be contacted by the
+Proceedings Chairs to assist in reviewing at least one paper.
+
+Further instructions can be found here:
+  {{readme_url['authors']}}
+  
+You can 
+  {{built_proceedings_url}}
+
+
+Sincerely, the SciPy {{year}} Proceedings Chairs,
+
+{{for cochair in committee}}
+- {{cochair['name']}} <{{cochair['email']}}>
+{{endfor}}
+

--- a/publisher/mail/templates/call_for_papers.txt.tmpl
+++ b/publisher/mail/templates/call_for_papers.txt.tmpl
@@ -8,7 +8,7 @@ Content-Type: text/plain
 Dear {{author}},
 
 Congratulations on having your abstract accepted for this year's event -- we 
-look forward to seeing your poster or presentation! As in the past, SciPy2018 
+look forward to seeing your poster or presentation! As in the past, {{conference}} 
 will release a conference proceedings prior to the start of the conference, 
 and you are invited to contribute a full-length paper (up to 8 pages) expanding 
 on your abstract.
@@ -22,8 +22,11 @@ scientific computing in Python, such as:
 - hardware systems designed to support the Python stack
 - applications of scientific computing in education
 
-Papers must be submitted as pull requests by {{submission_date}}. At that
-point, the six-week open review period will begin. During this time, members
+To submit a paper to the proceedings, submit a pull request to {{github_url}}.
+
+Papers must be submitted as pull requests by {{submission_date}}. 
+
+At that point, the six-week open review period begins. During this time, members
 from the program committee and the scientific Python community at large will
 provide feedback, which should be addressed through discussion on GitHub and by
 updating the pull request.
@@ -34,11 +37,11 @@ Proceedings Chairs to assist in reviewing at least one paper.
 Further instructions can be found here:
   {{readme_url['authors']}}
   
-You can 
+You can see all the papers that have been submitted so far at this site: 
   {{built_proceedings_url}}
 
 
-Sincerely, the SciPy {{year}} Proceedings Chairs,
+Sincerely, the {{conference}} Proceedings Chairs,
 
 {{for cochair in committee}}
 - {{cochair['name']}} <{{cochair['email']}}>

--- a/publisher/mail/templates/call_for_papers.txt.tmpl
+++ b/publisher/mail/templates/call_for_papers.txt.tmpl
@@ -7,11 +7,11 @@ Content-Type: text/plain
 
 Dear {{author}},
 
-Congratulations on having your abstract accepted for this year's event -- we 
-look forward to seeing your poster or presentation! As in the past, {{conference}} 
-will release a conference proceedings prior to the start of the conference, 
-and you are invited to contribute a full-length paper (up to 8 pages) expanding 
-on your abstract.
+Congratulations on having your abstract "{{title}}" accepted for this
+year's event -- we look forward to seeing your poster or presentation! As in
+the past, {{conference}} will release a conference proceedings prior to the
+start of the conference, and you are invited to contribute a full-length paper
+(up to 8 pages) expanding on your abstract.
 
 The proceedings are aimed at highlighting significant contributions to 
 scientific computing in Python, such as:

--- a/publisher/mail/templates/call_for_papers.txt.tmpl
+++ b/publisher/mail/templates/call_for_papers.txt.tmpl
@@ -1,5 +1,5 @@
 From: {{sender['name'] | html}}
-Subject: [{{conference}}] invitation to submit to proceedings
+Subject: [{{conference}}] Invitation to submit to the {{conference}} Proceedings
 To: {{recipients | html}}
 Cc: {{editor_email_string | html}}
 MIME-Version: 1.0

--- a/publisher/mail/templates/doi-notification.txt.tmpl
+++ b/publisher/mail/templates/doi-notification.txt.tmpl
@@ -1,7 +1,7 @@
 From: {{proceedings['xref']['depositor_email'] | html}}
 Subject: Your {{proceedings['title']['acronym']}} {{proceedings['year']}} Paper DOI
-To: {{author_email | html}}
-Cc: {{proceedings['editor_email'] | html}}
+To: {{recipients | html}}
+Cc: {{editor_email_string | html}}
 MIME-Version: 1.0
 Content-Type: text/plain
 
@@ -11,4 +11,6 @@ Your paper from the {{proceedings['title']['ordinal']}} {{proceedings['title']['
 
 Yours,
 {{proceedings['xref']['depositor_name']}}, on behalf of:
-  {{committee}}
+{{for cochair in committee}}
+- {{cochair['name']}} <{{cochair['email']}}>
+{{endfor}}

--- a/publisher/mail/templates/reviewer-invite.txt.tmpl
+++ b/publisher/mail/templates/reviewer-invite.txt.tmpl
@@ -1,7 +1,7 @@
 From: {{sender['name'] | html}}
 Subject: [{{conference}}] invitation to review proceedings
-To: {{email | html}}
-Cc: {{cced | html}}
+To: {{recipients | html}}
+Cc: {{editor_email_string | html}}
 MIME-Version: 1.0
 Content-Type: text/plain
 
@@ -33,4 +33,6 @@ Please note that reviews are made public, including the reviewer's name.
 
 With best regards,
 
-{{editors}}
+{{for cochair in committee}}
+- {{cochair['name']}} <{{cochair['email']}}>
+{{endfor}}


### PR DESCRIPTION
So this does a few things to improve our existing email generating system.

The first thing it does is it standardises a few of the fields that had previously been template specific.

The second thing it does is introduces a new Mailer class which contains the common logic for all of the email scripts and reduces the amount of boilerplate we need to keep around in each script.

this new Mailer object is intended to be subclassed with the ability to customise the fields needed for the particular template with the `custom_data` property, as can be seen in the call_for_papers example.

@dalippa and @deniederhut If you have a chance to look at this, I'd appreciate it… i'm probably going to use this to send out the emails as soon as I have the list and I figure out how to hook this up to my gmail.

My (hard) todos on this are:

- [x] Get session to connect appropriately
- [x] Fix/clarify authentication logic
- [x] setup new authors json based on the papers info

My (soft) todos on this are:
- [ ] update other scripts to use Mailer
- [x] setup nicer addresses for the recipients

