### PR TITLE
BUG: adds recent years to sidebar on html page

### DIFF
--- a/publisher/_static/proc_links.js
+++ b/publisher/_static/proc_links.js
@@ -1,5 +1,5 @@
 function proc_versions() {
-   var versions = ['2011', '2010', '2009', '2008'];
+   var versions = ['2017', '2016', '2015', '2014', '2013', '2012', '2011', '2010', '2009', '2008'];
    var proc_url = 'http://conference.scipy.org/proceedings/scipy';
    document.write('<ul id="navibar">');
 


### PR DESCRIPTION
From what I can gather, the previous practice has been to
modify the server's local copy of the proc_link.js file it
keeps in the root of the proceedings material (which is why
the website currently has years that are not in the copy of
proc_link.js available from the repo).