### PR TITLE
DOC: removes novelty requirement from review criteria

### DIFF
--- a/review_criteria.md
+++ b/review_criteria.md
@@ -1,8 +1,8 @@
 # Suggested Review Criteria for SciPy Proceedings
 
-A small subcommittee of the SciPy 2017 organizing committee has created this 
+A small subcommittee of the SciPy 2017 organizing committee has created this
 set of suggested review criteria
-to help guide authors and reviewers alike. Suggestions and amendments to these 
+to help guide authors and reviewers alike. Suggestions and amendments to these
 review criteria are enthusiastically welcomed via discussion or pull request.
 
 
@@ -11,9 +11,9 @@ review criteria are enthusiastically welcomed via discussion or pull request.
 - Prose should be written in English.
 - Prose should clearly and consistently communicate the narrative (e.g. consistent
   tense and person; use of active voice; etc)
-- The written style should convey information that furthers the knowledge or 
+- The written style should convey information that furthers the knowledge or
   research of the reader.
-- Due to the interdisciplinary nature of SciPy, highly domain-specific jargon 
+- Due to the interdisciplinary nature of SciPy, highly domain-specific jargon
   should be avoided or explained where possible.
 - Papers that do not meet quality standards may not be approved for publication.
 
@@ -21,21 +21,14 @@ review criteria are enthusiastically welcomed via discussion or pull request.
 
 - The technical content should be scientifically sound.
 - Computational content should, likewise, be verified.
-- The work should describe the development or use of python software for 
+- The work should describe the development or use of python software for
   approaching a problem in a domain within the scope of the conference.
-
-## Novelty and Impact
-
-- The work should employ new or innovative methods or approaches to a problem.
-- The work should advance the state of a scientific domain, the practice 
-  of scientific computing itself, or another subject area within the scope of 
-  the conference.
 
 ## Verifiability
 
-- Software descriptions should be accompanied by references to or examples of 
+- Software descriptions should be accompanied by references to or examples of
   representative source code.
-- Source code essential to the conclusions of the paper should be made 
+- Source code essential to the conclusions of the paper should be made
   available to the reader.
 - Data sources should be identified (e.g., with citation to a persistent DOI).
 - Analysis should be accompanied by a workflow description sufficient
@@ -46,7 +39,7 @@ review criteria are enthusiastically welcomed via discussion or pull request.
 - All mentioned software should be formally and consistently cited wherever
   possible.
 - Acronyms should be spelled out upon first mention.
-- License conditions on images and figures must be respected (Creative Commons, 
+- License conditions on images and figures must be respected (Creative Commons,
   etc.).
 - Mathematical and other symbols should be defined.
 - Definitions should include consistent units where appropriate.
@@ -57,11 +50,11 @@ review criteria are enthusiastically welcomed via discussion or pull request.
 ### Length
 
 - The compiled version should be no longer than 8 pages, including figures, source
-  code, appendices, etc.  
+  code, appendices, etc.
 
 ### Figures
 
-- All figures and tables should have captions. 
+- All figures and tables should have captions.
 - Figure text should be of a readable size.
 
 ### Code Snippets


### PR DESCRIPTION
On two 2018 submissions (#413 and #400), proceedings reviewers
have been confused about the extent to which they are meant
to be assessing the scientific impact of papers. As discussed in
a private email exchange and again in committee, the current
chairs feel that this assessment is performed during the work of
the program committee in deciding which papers are to be admitted
to the conference. As such, we are removing the language about
novelty and impact from the proceedings review criteria.

If you are creating this PR in order to submit a draft of your paper,
see http://procbuild.scipy.org/ for logs generated by the build
process.

See the [project readme](https://github.com/scipy-conference/scipy_proceedings#build-your-paper)
for more information.
