### PR TITLE
Edit Accepted Paper: Cloudknot, Fix typo in argument of monte_pi_count

### DIFF
--- a/papers/adam_richie-halford/adam_richie-halford.rst
+++ b/papers/adam_richie-halford/adam_richie-halford.rst
@@ -310,7 +310,7 @@ We submit jobs with the :code:`Knot.map()` method:
 
 .. code-block:: python
 
-   import numpy as np  # for np.linspace
+   import numpy as np  # for np.ones
    n_jobs, n_samples = 1000, 100000000
    args = np.ones(n_jobs, dtype=np.int32) * n_samples
    future = knot.map(args)

--- a/papers/adam_richie-halford/adam_richie-halford.rst
+++ b/papers/adam_richie-halford/adam_richie-halford.rst
@@ -291,7 +291,7 @@ in the source code of the UDF itself.
 
    import cloudknot as ck
 
-   def monte_pi_count(b):
+   def monte_pi_count(n):
        import numpy as np
        x = np.random.rand(n)
        y = np.random.rand(n)


### PR DESCRIPTION
This PR fixes a typo in the argument to the example `monte_pi_count` function. The old argument was `b` and should be `n`. My apologies for not catching this during the review process.
