### PR TITLE
BUG: cleans build and output before build

### DIFF
--- a/publisher/Makefile
+++ b/publisher/Makefile
@@ -35,7 +35,7 @@ students-pdf: $(TEXDIR)/students.pdf
 
 front-pdf: title-pdf copyright-pdf organization-pdf students-pdf
 
-papers:
+papers: clean
 	./build_papers.py
 
 proceedings: papers $(TEXDIR)/proceedings.tex front-pdf


### PR DESCRIPTION
This prevents leftover latex files from previous build from
persisting and causing hard-to-track-down errors.
Closes #422