### PR TITLE
[2017] Correct video link for NEXT talk

### DIFF
--- a/papers/scott_sievert/next.rst
+++ b/papers/scott_sievert/next.rst
@@ -26,7 +26,7 @@
 :email: Bob_Mankoff@newyorker.com
 :institution: The New Yorker
 
-:video: http://www.youtube.com/watch?v=dhRUe-gz690
+:video: https://www.youtube.com/watch?v=blPjDYCvppY
 :bibliography: refs
 
 


### PR DESCRIPTION
When I wrote the paper I left the default link in thinking it'd automatically be changed (by default, it linked to a Monty Python video; it's down now).

This corrects the link to the link I thought would be automatically inserted.