### PR TITLE
talk: Add pyhf SciPy 2020 talk and information

### DIFF
--- a/presentations/slides/pyhf/info.json
+++ b/presentations/slides/pyhf/info.json
@@ -1,0 +1,7 @@
+{
+    "title": "pyhf: a pure Python statistical fitting library with tensors and autograd",
+    "authors": [
+        "Matthew Feickert"
+    ],
+    "description": "pyhf is a pure-Python implementation of the HistFactory statistical model for multi-bin histogram-based analysis with asymptotic interval estimation, and part of the Scikit-HEP project ecosystem. pyhf supports modern computational graph libraries as computational backends in order to make use of features such as auto-differentiation and GPU acceleration. Additionally, the statistical models are defined in a declarative JSON schema, readily enabling preservation and distribution through services such as the Durham High-Energy Physics Database (HEPData)."
+}


### PR DESCRIPTION
Add [`pyhf` talk presented at SciPy 2020](https://github.com/matthewfeickert/talk-SciPy-2020) by @matthewfeickert on behalf of the `pyhf` dev team.

Note: This PR is set to a draft for the time being so that responses to any questions received in the Q&A session can be addressed in the "backup" slides after the fact for posterity. Once those are in the PDF I'll move it to being ready for review.
