### PR TITLE
Paper: HOOMD - Change MoSDeF reference

### DIFF
--- a/papers/brandon_butler/paper.rst
+++ b/papers/brandon_butler/paper.rst
@@ -67,12 +67,12 @@ have used other interfaces have also added Python bindings such as LAMMPS and GR
 
 In the development of these tools, the requirements for the software to enable good science became
 more obvious. Having computational research that is Transferable, Reproducible, Usable (by others),
-and Extensible (TRUE) :cite:`summers.etal2020` is necessary for fully realizing the potential of
+and Extensible (TRUE) :cite:`thompson.etal2020` is necessary for fully realizing the potential of
 computational molecular science. HOOMD-blue is part of the MoSDeF project which seeks to bring these
 traits to the wider computational molecular science community through packages like mbuild
 :cite:`klein.etal2016` and foyer :cite:`klein.etal2019` which are Python packages that generalize
 generating initial particle configurations and force fields respectively across a variety of
-simulation back ends :cite:`cummings.gilmer2019, summers.etal2020`. This effort in increased
+simulation back ends :cite:`cummings.gilmer2019, thompson.etal2020`. This effort in increased
 TRUEness is one of many motivating factors for HOOMD-blue version 3.0.
 
 HOOMD-blue :cite:`anderson.etal2008, glaser.etal2015, anderson.etal2020`, an MD and MC simulations

--- a/papers/brandon_butler/references.bib
+++ b/papers/brandon_butler/references.bib
@@ -1,4 +1,3 @@
-
 @article{abraham.etal2015,
   title = {{{GROMACS}}: {{High}} Performance Molecular Simulations through Multi-Level Parallelism from Laptops to Supercomputers},
   shorttitle = {{{GROMACS}}},
@@ -766,22 +765,22 @@ Program Title: freud Program Files doi: http://dx.doi.org/10.17632/v7wmv9xcct.1 
   number = {1}
 }
 
-@article{summers.etal2020,
-  title = {{{MoSDeF}}, a {{Python Framework Enabling Large}}-{{Scale Computational Screening}} of {{Soft Matter}}: {{Application}} to {{Chemistry}}-{{Property Relationships}} in {{Lubricating Monolayer Films}}},
-  shorttitle = {{{MoSDeF}}, a {{Python Framework Enabling Large}}-{{Scale Computational Screening}} of {{Soft Matter}}},
-  author = {Summers, Andrew Z. and Gilmer, Justin B. and Iacovella, Christopher R. and Cummings, Peter T. and McCabe, Clare},
-  date = {2020-03-10},
-  journaltitle = {J. Chem. Theory Comput.},
-  volume = {16},
-  pages = {1779--1793},
-  publisher = {{American Chemical Society}},
-  issn = {1549-9618},
-  doi = {10.1021/acs.jctc.9b01183},
-  url = {https://doi.org/10.1021/acs.jctc.9b01183},
-  urldate = {2020-05-29},
-  abstract = {We demonstrate how the recently developed Python-based Molecular Simulation and Design Framework (MoSDeF) can be used to perform molecular dynamics screening of functionalized monolayer films, focusing on tribological effectiveness. MoSDeF is an open-source package that allows for the programmatic construction and parametrization of soft matter systems and enables TRUE (transferable, reproducible, usable by others, and extensible) simulations. The MoSDeF-enabled screening identifies several film chemistries that simultaneously show low coefficients of friction and adhesion. We additionally develop a Python library that utilizes the RDKit cheminformatics library and the scikit-learn machine learning library that allows for the development of predictive models for the tribology of functionalized monolayer films and use this model to extract information on terminal group characteristics that most influence tribology, based on the screening data.},
-  file = {/home/brandon/Zotero/storage/D7T7KKF4/Summers et al. - 2020 - MoSDeF, a Python Framework Enabling Large-Scale Co.pdf;/home/brandon/Zotero/storage/CIBMUUJI/acs.jctc.html},
-  number = {3}
+@article{thompson.etal2020,
+  title = {Towards Molecular Simulations That Are Transparent, Reproducible, Usable by Others, and Extensible ({{TRUE}})},
+  author = {Thompson, Matthew W. and Gilmer, Justin B. and Matsumoto, Ray A. and Quach, Co D. and Shamaprasad, Parashara and Yang, Alexander H. and Iacovella, Christopher R. and McCabe, Clare and Cummings, Peter T.},
+  date = {2020-06-01},
+  journaltitle = {Molecular Physics},
+  volume = {118},
+  pages = {e1742938},
+  publisher = {{Taylor \& Francis}},
+  issn = {0026-8976},
+  doi = {10.1080/00268976.2020.1742938},
+  url = {https://doi.org/10.1080/00268976.2020.1742938},
+  urldate = {2020-07-10},
+  abstract = {Systems composed of soft matter (e.g. liquids, polymers, foams, gels, colloids, and most biological materials) are ubiquitous in science and engineering, but molecular simulations of such systems pose particular computational challenges, requiring time and/or ensemble-averaged data to be collected over long simulation trajectories for property evaluation. Performing a molecular simulation of a soft matter system involves multiple steps, which have traditionally been performed by researchers in a ‘bespoke’ fashion, resulting in many published soft matter simulations not being reproducible based on the information provided in the publications. To address the issue of reproducibility and to provide tools for computational screening, we have been developing the open-source Molecular Simulation and Design Framework (MoSDeF) software suite. In this paper, we propose a set of principles to create Transparent, Reproducible, Usable by others, and Extensible (TRUE) molecular simulations. MoSDeF facilitates the publication and dissemination of TRUE simulations by automating many of the critical steps in molecular simulation, thus enhancing their reproducibilitya. We provide several examples of TRUE molecular simulations: All of the steps involved in creating, running and extracting properties from the simulations are distributed on open-source platforms (within MoSDeF and on GitHub), thus meeting the definition of TRUE simulations.},
+  file = {/home/brandon/Zotero/storage/ZMCT3RDF/Thompson et al. - 2020 - Towards molecular simulations that are transparent.pdf;/home/brandon/Zotero/storage/DTQ9QDZ4/00268976.2020.html},
+  keywords = {Molecular dynamics,Monte Carlo simulation,open-source,reproducibility},
+  number = {9-10}
 }
 
 @article{vanderwalt.etal2011,


### PR DESCRIPTION
There was a more recent paper that was published on MoSDeF that occurred during the writing of this paper. It was pointed out that the citation for the *TRUE*ness of simulations makes more sense with the new publication. This changes publications accordingly.