### PR TITLE
Add Mjolnir talk PDF from SciPy 2020

### DIFF
--- a/presentations/slides/mjolnir/info.json
+++ b/presentations/slides/mjolnir/info.json
@@ -1,0 +1,7 @@
+{
+    "title": "Project Mjolnir: A Modular, Open-source Platform for Developing Scientific IoT Sensor Networks",
+    "authors": [
+        "C.A.M. Gerlach"
+    ],
+    "description": "From a humble beginning as a side effort using a Raspberry Pi to talk to lightning instruments, Project Mjolnir is evolving into a modular, open source client-server platform for developing scientific IoT sensor networks. Its goal is to enable scientists of many disciplines to employ low-cost hardware to robustly ingest, log and uplink periodic and on-demand science and engineering data and commands, controlled either autonomously or centrally, all with little or no bespoke code. The talk will discuss Mjolnir’s development and future, present examples of current projects built on it, and explore how to leverage it for new applications."
+}


### PR DESCRIPTION
I can also include the LibreOffice ODP as well, though with the enormous size of this repo (> 500 MB) that might not be advisable. 

Has there been consideration of splitting it into repos by year with a separate one for common tools/build system, to make clones, pulls and pushes not take a large amount of time, especially for those without access to high-bandwidth internet at the moment? Thanks!