### PR TITLE
Update citation with DOI

### DIFF
--- a/papers/zac_hatfield-dodds/references.bib
+++ b/papers/zac_hatfield-dodds/references.bib
@@ -13,13 +13,22 @@
   journal = {Journal of Open Source Software}
 }
 
-% TODO: to be replaced by formal citation as soon as one is available
-@Unpublished{MacIver2020,
-  author    = {David MacIver and Alastair Donaldson},
-  title     = {Test-Case Reduction via Test-Case Generation: Insights From the Hypothesis Reducer},
-  publisher = {ECOOP},
-  url       = {https://drmaciver.github.io/papers/reduction-via-generation-preview.pdf},
-  note      = {to be published in \url{https://2020.ecoop.org/details/ecoop-2020-papers/13/Test-Case-Reduction-via-Test-Case-Generation-Insights-From-the-Hypothesis-Reducer}}
+@article{MacIver2020,
+  author =	{David R. MacIver and Alastair F. Donaldson},
+  title =	{{Test-Case Reduction via Test-Case Generation: Insights from the Hypothesis Reducer (Tool Insights Paper)}},
+  booktitle =	{34th European Conference on Object-Oriented Programming (ECOOP 2020)},
+  pages =	{13:1--13:27},
+  series =	{Leibniz International Proceedings in Informatics (LIPIcs)},
+  ISBN =	{978-3-95977-154-2},
+  ISSN =	{1868-8969},
+  year =	{2020},
+  volume =	{166},
+  editor =	{Robert Hirschfeld and Tobias Pape},
+  publisher =	{Schloss Dagstuhl--Leibniz-Zentrum f{\"u}r Informatik},
+  address =	{Dagstuhl, Germany},
+  URL =		{https://drops.dagstuhl.de/opus/volltexte/2020/13170},
+  URN =		{urn:nbn:de:0030-drops-131700},
+  doi =		{10.4230/LIPIcs.ECOOP.2020.13},
 }
 
 @misc{PraisePBT,


### PR DESCRIPTION
Unfortunately this took a lot longer than expected - since the ECOOP conference went delayed then virtual - but the formal citation is now available.