### PR TITLE
talk: Add pyhf and funcX SciPy 2021 talk and information

### DIFF
--- a/presentations/slides/pyhf-funcx/info.json
+++ b/presentations/slides/pyhf-funcx/info.json
@@ -1,0 +1,11 @@
+{
+    "title": "Distributed statistical inference with pyhf powered by funcX",
+    "authors": [
+        {
+            "name": "Matthew Feickert",
+            "affiliation": "University of Illinois at Urbana-Champaign",
+            "orcid": "0000-0003-4124-7862"
+        }
+    ],
+    "description": "In high energy physics (HEP) a core component of analysis of data collected at the Large Hadron Collider is performing statistical inference for binned models to extract physics information. The statistical fitting tools used in HEP have traditionally been implemented in C++, but in recent years pyhf, a pure-Python library with automatic differentiation and hardware acceleration, has grown in use for analysis related statistical inference problems. The fitting of multiple different hypotheses for new physics signatures (signals) is a computational problem that lends itself easily to parallelization, but is hampered on HPC environments by the additional tooling overhead required, which can be very difficult to master. Through use of funcX, a pure-Python high performance function serving system designed to orchestrate scientific workloads across heterogeneous computing resources, pyhf can be used as a highly scalable (fitting) function as a service (FaaS) on HPCs."
+}


### PR DESCRIPTION
Add [`pyhf` talk presented at SciPy 2021](https://github.com/matthewfeickert/talk-scipy-2021) by @matthewfeickert on behalf of the `pyhf` dev team and Ben Galewsky of `funcX`.