### PR TITLE
Adding Sarthak Jariwala's lightning talk on `seaborn-image`

### DIFF
--- a/presentations/lightning/seaborn-image/info.json
+++ b/presentations/lightning/seaborn-image/info.json
@@ -1,0 +1,11 @@
+{
+  "title" : "seaborn-image : image data visualization in Python",
+  "authors" : [
+    {
+      "name": "Sarthak Jariwala",
+      "affiliation": "University of Washington, Seattle",
+      "orcid": "0000-0002-7020-9008"
+    }
+  ],
+  "description" : "High level API for attractive and descriptive image visualization in Python built on top of matplotlib" 
+}


### PR DESCRIPTION
Adding information and slides for my lightning talk on [`seaborn-image`](https://github.com/SarthakJariwala/seaborn-image) presented at SciPy 2021.