### PR TITLE
Add booktabs package to LaTeX preamble for formatting tables

### DIFF
--- a/publisher/_static/scipy.sty
+++ b/publisher/_static/scipy.sty
@@ -61,6 +61,7 @@
 }
 
 \usepackage{multirow}
+\usepackage{booktabs}
 \newlength{\tablewidth}
 \setlength{\tablewidth}{\linewidth}
 


### PR DESCRIPTION
This PR intends to update the build process to include the `booktabs` LaTeX package. This is to be used for formatting tables in a readable manner when they would otherwise be convoluted.
