### PR TITLE
BUG: Paper: Bayesian Estimation and Forecasting of Time Series in statsmodels

### DIFF
--- a/papers/chad_fulton/chad_fulton.rst
+++ b/papers/chad_fulton/chad_fulton.rst
@@ -486,7 +486,7 @@ computation introduced above.
    :scale: 50%
    :align: center
 
-   Approximate posterior distribution of variance parameter, random walk model, Metropolis-Hastings; CPI inflation. :label:`mhsamples`
+   Approximate posterior distribution of variance parameter, random walk model, Metropolis-Hastings; U.S. Industrial Production. :label:`mhsamples`
 
 The approximate posterior distribution, constructed from the sample chain,
 is shown in Figure :ref:`mhsamples`.


### PR DESCRIPTION
While finalizing the associated poster for SciPy 2022, I noticed that the title for Figure 2 referenced the incorrect series.  It said "CPI Inflation" when the results were actually associated with the "U.S. Industrial Production" dataset.

Apologies for the extra work involved here.

xref #723