### PR TITLE
Add slides for NumPy (Ufunc/dtypes) talk

### DIFF
--- a/presentations/slides/numpy/info.json
+++ b/presentations/slides/numpy/info.json
@@ -1,0 +1,16 @@
+{
+    "title": "UFuncs and DTypes: new possibilities in NumPy",
+    "authors": [
+        {
+             "name": "Sebastian Berg",
+             "affiliation": "BIDS, UC Berkeley",
+             "orcid": "0000-0002-1236-259X"
+        },
+        {
+             "name": "Stéfan van der Walt",
+             "affiliation": "BIDS, UC Berkeley",
+             "orcid": "0000-0001-9276-1891"
+        }
+    ],
+    "description": "Over the past three years, NumPy has seen large changes to much of its core functionalities including universal functions, casting, and DTypes. The goal of this refactoring was to introduce extensible APIs to improve existing user-defined DTypes and unlock new ones. This refactoring is nearing its conclusion, with the work being surfaced as public-facing API. In this talk we will discuss what has been done, and newly possible applications—such as a custom NumPy DType that is aware of physical units."
+}


### PR DESCRIPTION
These are the slides for:

     UFuncs and DTypes: new possibilities in NumPy

(slightly shortened to not include slides with appearing fragments, where the following page would include strictly more information.)

Ping @stefanv.