### PR TITLE
BUG: clear output dir before building

### DIFF
--- a/publisher/build_paper.py
+++ b/publisher/build_paper.py
@@ -237,6 +237,8 @@ def detect_paper_type(in_path: str) -> str:
 def prepare_dir(in_path: str, out_path: str, start: int):
     """Copy required files to build dir
     """
+    # clear out whatever cruft might be in the output dir
+    shutil.rmtree(out_path)
     # copy the whole source folder to the build directory
     dir_util.copy_tree(in_path, out_path)
     base_dir = os.path.dirname(__file__)


### PR DESCRIPTION
When searching for the latex source file, we glob the output dir for anything that ends in '.tex'. When we build the paper, we inject the source file into our template and call the output paper.tex. If you try to build twice, we find both the source and the output ending in tex and raise an error.

Probably the real way to solve this problem is to have users specify the paper's file name in their metadata file. For now, we can clean the output dir before each build to avoid seeing too many .tex files.

Closes #797