### PR TITLE
Revert from ieeetr to alphaurl style

### DIFF
--- a/publisher/_templates/paper.tex.tmpl
+++ b/publisher/_templates/paper.tex.tmpl
@@ -40,7 +40,7 @@
 {{body}}
 
 % bibliography
-\bibliographystyle{ieeetr}
+\bibliographystyle{alphaurl}
 \bibliography{ {{bibliography}} }
 
 \end{document}

--- a/publisher/writer/__init__.py
+++ b/publisher/writer/__init__.py
@@ -109,7 +109,7 @@ class Translator(LaTeXTranslator):
             self.latex_video_url = text
             self.video_url = node.astext() if text else ''
         elif self.current_field == 'bibliography':
-            self.bibtex = ['ieeetr', text]
+            self.bibtex = ['alphaurl', text]
             self._use_latex_citations = True
             self._bibitems = ['', '']
             self.bibliography = text


### PR DESCRIPTION
This PR reverts back to alphaurl [urlbst](url) BiBTeX style to preserve hyperlink formatting in references via the urlbst fields `url` and `doi`.

Closes https://github.com/scipy-conference/scipy_proceedings/issues/811