### PR TITLE
Update PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,8 +1,6 @@
-If you are creating this PR in order to submit a draft of your paper,
-please tag your PR with `paper` and a GitHub Action will be run to check and build your paper.
+If you are creating this PR in order to submit a draft of your paper, please name your PR with `Paper: <title>`. An editor will then add a `paper` label and GitHub Action will be run to check and build your paper.
 
-See the [project readme](https://github.com/scipy-conference/scipy_proceedings#preview-your-paper)
-for more information.
+See the [project readme](https://github.com/scipy-conference/scipy_proceedings#preview-your-paper) for more information.
 
 _Editor_: <!--editor--> <!--end-editor-->
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-If you are creating this PR in order to submit a draft of your paper, please name your PR with `Paper: <title>`. An editor will then add a `paper` label and GitHub Action will be run to check and build your paper.
+If you are creating this PR in order to submit a draft of your paper, please name your PR with `Paper: <title>`. An editor will then add a `paper` label and GitHub Actions will be run to check and build your paper.
 
 See the [project readme](https://github.com/scipy-conference/scipy_proceedings#preview-your-paper) for more information.
 


### PR DESCRIPTION
External contributors will not be able to add tags to their PR. This updates the language around that.

As editors, when a PR comes in, we will need to (1) do a quick review (e.g. was this paper accepted by SciPy); (2) add a PR label of `paper`; (3) rerun the action.