### PR TITLE
Update author invitation email template for 2024

### DIFF
--- a/publisher/mail/templates/author-invitation.txt.tmpl
+++ b/publisher/mail/templates/author-invitation.txt.tmpl
@@ -1,6 +1,6 @@
 Dear @firstname @lastname,
 
-Congratulations on having your abstract, "@title" accepted for this year's event -- we look forward to seeing your poster or presentation! As in the past, SciPy 2024 will release a conference proceedings after the end of the conference, and you are invited to contribute a full-length paper (up to 8 pages, not including references) expanding on your abstract. Note: this is optional and not required for you to present at the conference.
+Congratulations on having your abstract, "@title" accepted for this year's event -- we look forward to seeing your poster or presentation! As in the past, SciPy 2024 will release a conference proceedings after the end of the conference, and you are invited to contribute a full-length paper (up to 6000 words (about 8 pages), not including references) expanding on your abstract. Note: this is optional and not required for you to present at the conference.
 
 The proceedings are aimed at highlighting significant contributions to scientific computing in Python, including but not limited to:
     - methods for high performance computing in Python

--- a/publisher/mail/templates/author-invitation.txt.tmpl
+++ b/publisher/mail/templates/author-invitation.txt.tmpl
@@ -1,6 +1,6 @@
-Dear {{to_name}},
+Dear @firstname @lastname,
 
-Congratulations on having your abstract, "{{title}}", accepted for this year's event -- we look forward to seeing your poster or presentation! As in the past, {{proceedings['title']['acronym']}} {{proceedings['year']}} will release a conference proceedings prior to the start of the conference, and you are invited to contribute a full-length paper (up to 8 pages, not including references) expanding on your abstract.
+Congratulations on having your abstract, "@title" accepted for this year's event -- we look forward to seeing your poster or presentation! As in the past, SciPy 2024 will release a conference proceedings after the end of the conference, and you are invited to contribute a full-length paper (up to 8 pages, not including references) expanding on your abstract. Note: this is optional and not required for you to present at the conference.
 
 The proceedings are aimed at highlighting significant contributions to scientific computing in Python, including but not limited to:
     - methods for high performance computing in Python
@@ -8,17 +8,27 @@ The proceedings are aimed at highlighting significant contributions to scientifi
     - domain-specific applications of Python in any field of research
     - significant improvements to existing scientific Python packages
 
-Papers must be submitted as pull requests via GitHub by May 28th, 2020. At that point, the five-week open review period will begin. During this time, members from the proceedings committee and the scientific Python community at large will provide feedback, which should be addressed through discussion on GitHub and by updating the pull request. Further instructions can be found here:
+Papers must be submitted as pull requests via GitHub by May 31st, 2024. At that point, the eight-week open review period will begin. Papers must be complete before they are submitted (e.g. no missing or half-written sections). During this time, members from the proceedings committee and the scientific Python community at large will provide feedback, which should be addressed through discussion on GitHub and by updating the pull request. Further instructions can be found here:
 https://github.com/scipy-conference/scipy_proceedings#instructions-for-authors
+
+A webinar with walkthrough and Q&A on how to submit to the proceedings will be offered on May 3rd, 2024. Sign up can be found here:
+https://www.eventbrite.ca/e/scipy-proceedings-2024-quickstart-and-authoring-tutorial-tickets-876683101757
 
 When submitting a paper to the proceedings, you may be contacted by the Proceedings Chairs to assist in reviewing other papers.
 
-After the conference, you will have the opportunity to submit electronic copies of your poster or talk slides for archiving with {{proceedings['title']['acronym']}}. Further information about submitting slides and posters can be found here: https://github.com/scipy-conference/scipy_proceedings#instructions-for-slides
+After the conference has ended, you will have the opportunity to submit electronic copies of your poster or talk slides for archiving with SciPy. Further information about submitting slides and posters can be found here: https://github.com/scipy-conference/scipy_proceedings#instructions-for-slides
 
 Yours,
-The {{proceedings['title']['acronym']}} {{proceedings['year']}} Proceedings Committee
-{{for n in proceedings['editor']}}
-  {{n}}
-{{endfor}}
+The SciPy 2024 Proceedings Committee
+Co-chairs / Editors:
+   Meghann Agarwal
+   Amey Ambade
+   Chris Calloway
+   Rowan Cockett
+   Sanhita Joshi
+   Charles Lindsey
+   Hongsup Shin
+--
+Unsubscribe
 
 


### PR DESCRIPTION
The author invitation will be sent using Gmail mail merge from the proceedings at scipy.org email account. The @ fields will be substituted with column values from a spreadsheet.