### PR TITLE
Slides: Keynote Particles, People, and Pull Requests

### DIFF
--- a/presentations/slides/cranmer-kyle/info.json
+++ b/presentations/slides/cranmer-kyle/info.json
@@ -1,0 +1,11 @@
+{
+    "title": "Particles, People, and Pull Requests",
+    "authors": [
+        {
+            "name": "Kyle Cranmer",
+            "affiliation": "University of Wisconsin-Madison",
+            "orcid": "0000-0002-5769-7094"
+        }
+    ],
+    "description": "I will tell the story of how the statistical challenges in the search for the Higgs boson and exotic new physics at the Large Hadron Collider led to new approaches to collaborative, open science. The story centers around computational and sociological challenges where software and cyberinfrastructure play a key role. I will highlight a few important changes in perspective that were critical for progress including embracing declarative specifications, pivoting from reproducibility to reuse, and the abstraction that led to the field of simulation-based inference."
+}


### PR DESCRIPTION
Submitting July 12, 2024 keynote slides on behalf of Kyle Cranmer, with his permission.