### PR TITLE
📈 Upgrade to new curvenote submit actions

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,18 +1,21 @@
-name: Publish all 2024 articles
-on: workflow_dispatch
+name: Create preview draft for 2024 articles
+on:
+  pull_request_target:
+    branches: ['2024']
 permissions:
   contents: read
   pull-requests: write
 jobs:
   publish:
-    uses: curvenote/actions/.github/workflows/submit.yml@v1
+    uses: curvenote/actions/.github/workflows/draft.yml@v1
     with:
       id-pattern-regex: '^scipy-2024-(?:[a-zA-Z0-9-_]{3,25})$'
+      enforce-single-folder: true
       venue: scipy
       collection: '2024'
       kind: Article
       path: papers/*
-      publish: true
+      label: draft
     secrets:
       CURVENOTE: ${{ secrets.CURVENOTE_TOKEN }}
       GITHUB: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,5 +1,8 @@
-name: Publish all 2024 articles
-on: workflow_dispatch
+name: Create submission for 2024 articles
+on:
+  pull_request_target:
+    branches: ['2024']
+    types: [labeled, opened, synchronize, reopened]
 permissions:
   contents: read
   pull-requests: write
@@ -8,11 +11,12 @@ jobs:
     uses: curvenote/actions/.github/workflows/submit.yml@v1
     with:
       id-pattern-regex: '^scipy-2024-(?:[a-zA-Z0-9-_]{3,25})$'
+      enforce-single-folder: true
       venue: scipy
       collection: '2024'
       kind: Article
       path: papers/*
-      publish: true
+      label: reviewed
     secrets:
       CURVENOTE: ${{ secrets.CURVENOTE_TOKEN }}
       GITHUB: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The previous github action used a deprecated curvenote workflow. We left it in place during the submission/review process, but now that things have settled down, I'm updating the actions so they get all the latest features and fixes.

This PR adds 3 actions. The first two basically replace the functionality of the old action:

1. `draft.yml` should create a preview draft on PRs labeled `draft` if they only include changes to a single folder inside `papers/`
2. `submit.yml` should create a submission on PRs labeled `reviewed` if they only include changes to a single folder inside `papers/`

Then totally new:

3. `publish.yml` should update submissions for _all_ articles in the `papers/` folder and it should also publish them. It is only triggered manually.