### PR TITLE
fix: Correct unit formatting

### DIFF
--- a/papers/matthew_feickert/uncovering-higgs.md
+++ b/papers/matthew_feickert/uncovering-higgs.md
@@ -39,7 +39,7 @@ m = {\frac{\sqrt{E^2 - p(c)^2}}{c^2}}
 ```
 where $E$ and $p$ is the total energy and momentum of the particles, respectively.
 
-By detecting and measuring the energies and momenta of the detected particles at the experiment, we can reconstruct the invariant mass of the decay system. Particle systems originating from the decay of the Higgs boson will have a characteristic value of the invariant mass, which after the discovery in 2012 we know it is about 125$GeV/c^2$.
+By detecting and measuring the energies and momenta of the detected particles at the experiment, we can reconstruct the invariant mass of the decay system. Particle systems originating from the decay of the Higgs boson will have a characteristic value of the invariant mass, which after the discovery in 2012 we know it is about $125~\mathrm{GeV}/c^2$.
 This is the quantity that will allow us to discriminate from particle systems that originate from background processes.
 
 ### Measurement uncertainties


### PR DESCRIPTION
The 'GeV' should be rendered as text in `mathrm`, not in math text, like it is elsewhere in the paper

https://github.com/scipy-conference/scipy_proceedings/blob/f792cb1d88e62384a276be0f235c91a79fd23179/papers/matthew_feickert/introduction.md?plain=1#L8

* Amends PR https://github.com/scipy-conference/scipy_proceedings/pull/924

This was an author mistake by me caught only while reviewing the render for Issue #1033 and #1034. Apologies for this, as I should have been more careful in the review!

| f792cb1d88e62384a276be0f235c91a79fd23179 | This PR |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/4204e0b9-1521-416b-8ec8-ebe9e34d1e7b) | ![image](https://github.com/user-attachments/assets/e0211076-4e96-4873-8475-d7cfa22d5c6c) |