### PR TITLE
fix: Fix typo in path to parent proceedings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ Editors should come to a final 'ready', 'unready' decision before the **Final Ed
 
 ```yaml
 version: 1
-extends: ../../proceedings.yml
+extends: ../../../proceedings.yml
 project:
   title: 'The title of your presentation'
   authors:


### PR DESCRIPTION
In the given template for submitting slides, etc. to the proceedings, the path under

```yaml
extends: ../../proceedings.yml
```

should actually be `../../../proceedings.yml` since the slides would be in a directory following the `presentations/slides/<name>` pattern, so there are 3 directories to go up to reach the `proceedings.yml` file at the root of the directory.