### PR TITLE
Fix typo in conference title

### DIFF
--- a/proceedings/myst.yml
+++ b/proceedings/myst.yml
@@ -6,7 +6,7 @@ site:
   nav: []
   template: article-theme
 project:
-  title: Proceedings of the 24rd Python in Science Conference
+  title: Proceedings of the 24th Python in Science Conference
   subtitle: SciPy 2025, Tacoma, Washington July 7 - July 13
   description: |
     The 24th annual SciPy conference was held in Tacoma, Washington at the Tacoma Convention Center, July 7-13, 2025.


### PR DESCRIPTION
Hi 

I was checking https://proceedings.scipy.org/articles/hptk5424 and noticed that in title it was "24rd" and should have been 24th.

I hope that helps,

Best regards,
Ivan


If you are creating this PR in order to submit a draft of your paper, please name your PR with `Paper: <title>`. An editor will then add a `draft` label; this will trigger GitHub Actions to run automated checks on your paper and build a preview. You may then work to resolve failed checks and ensure the preview build looks correct. If you have any questions, please tag the proceedings team in a comment on your PR with `@scipy-conference/2025-proceedings`.

See the [project readme](https://github.com/scipy-conference/scipy_proceedings#preview-your-paper) for more information.