### PR TITLE
feat(2026): Add Gen AI policy to SciPy 2026 Proceedings

### DIFF
--- a/genai_policy.md
+++ b/genai_policy.md
@@ -6,15 +6,15 @@ Principles:
 
 1. Use the tools you want, but disclose their usage. Generative AI tools (e.g., ChatGPT, Claude, Copilot) are permitted but their use must be transparently disclosed. When disclosure is required, state which tool you used, how you used it, and for what purpose. Standard spell-checkers, grammar tools, and code linters do not require disclosure.
 
-    > [!TIP]
-    > An example of disclosure could be as follows:
-    > 
-    > _Portions of this work were assisted using generative AI tools (specify tool, e.g., ChatGPT). The tools were used for (e.g., drafting text, refining language, or generating code suggestions). All outputs were reviewed, verified, and revised by the author(s), who take full responsibility for the accuracy and integrity of the final content._
+   > [!TIP]
+   > An example of disclosure could be as follows:
+   >
+   > _Portions of this work were assisted using generative AI tools (specify tool, e.g., ChatGPT). The tools were used for (e.g., drafting text, refining language, or generating code suggestions). All outputs were reviewed, verified, and revised by the author(s), who take full responsibility for the accuracy and integrity of the final content._
 
-2. AI cannot be an author or co-author. Authorship requires human accountability.
+1. AI cannot be an author or co-author. Authorship requires human accountability.
 
-3. You are responsible for everything you submit. This includes all content generated or refined with AI assistance (text, code, references, figures, etc.). AI tools may fabricate citations and produce plausible outputs. Trust, but verify everything.
+1. You are responsible for everything you submit. This includes all content generated or refined with AI assistance (text, code, references, figures, etc.). AI tools may fabricate citations and produce plausible outputs. Trust, but verify everything.
 
-4. Do not be an LLM proxy. Do not take someone's question, comment, or review and run it through an AI tool to generate your response. Engage with the substance yourself.
+1. Do not be an LLM proxy. Do not take someone's question, comment, or review and run it through an AI tool to generate your response. Engage with the substance yourself.
 
-5. Do your own reviewing. If you volunteered to review a proposal, paper, or submission, the review should reflect your expert judgment, not a machine's. Using AI to polish your own writing is fine; using it to generate your evaluation is not. Do not upload unpublished submissions into AI tools.
+1. Do your own reviewing. If you volunteered to review a proposal, paper, or submission, the review should reflect your expert judgment, not a machine's. Using AI to polish your own writing is fine; using it to generate your evaluation is not. Do not upload unpublished submissions into AI tools.

--- a/genai_policy.md
+++ b/genai_policy.md
@@ -1,0 +1,20 @@
+# Gen AI Policy
+
+The SciPy conference permits the use of generative AI tools (e.g., ChatGPT, Claude, Copilot) across all conference activities, but requires transparent disclosure of their use. AI tools may not be listed as authors or co-authors. All participants (authors, reviewers, and speakers) are fully responsible for the accuracy and integrity of their contributions, including any AI-assisted content. When in doubt about whether to disclose, err on the side of caution. This policy applies to all SciPy participants across all venues: proposals, talks, papers, proceedings, posters, and peer review.
+
+Principles:
+
+1. Use the tools you want, but disclose their usage. Generative AI tools (e.g., ChatGPT, Claude, Copilot) are permitted but their use must be transparently disclosed. When disclosure is required, state which tool you used, how you used it, and for what purpose. Standard spell-checkers, grammar tools, and code linters do not require disclosure.
+
+    > [!TIP]
+    > An example of disclosure could be as follows:
+    > 
+    > _Portions of this work were assisted using generative AI tools (specify tool, e.g., ChatGPT). The tools were used for (e.g., drafting text, refining language, or generating code suggestions). All outputs were reviewed, verified, and revised by the author(s), who take full responsibility for the accuracy and integrity of the final content._
+
+2. AI cannot be an author or co-author. Authorship requires human accountability.
+
+3. You are responsible for everything you submit. This includes all content generated or refined with AI assistance (text, code, references, figures, etc.). AI tools may fabricate citations and produce plausible outputs. Trust, but verify everything.
+
+4. Do not be an LLM proxy. Do not take someone's question, comment, or review and run it through an AI tool to generate your response. Engage with the substance yourself.
+
+5. Do your own reviewing. If you volunteered to review a proposal, paper, or submission, the review should reflect your expert judgment, not a machine's. Using AI to polish your own writing is fine; using it to generate your evaluation is not. Do not upload unpublished submissions into AI tools.


### PR DESCRIPTION
This PR adds the first draft of the Gen AI Policy. Addresses #1189. 